### PR TITLE
fix(prettier): make prettier ignore all mdx document files inside content/docs folder

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -45,3 +45,6 @@ pnpm-lock.yaml
 
 # Auto-generated files
 next-env.d.ts
+
+# MDX documents content
+content/docs/**/*.mdx


### PR DESCRIPTION
## 描述

调整`.prettierignore`规则文件，排除`content/docs/`文件夹下所有`mdx`文件。

## 相关问题

关闭 #96 

## 变更类型

- [x] Bug 修复（不会破坏现有功能的非破坏性变更）
- [ ] 新功能（添加功能的非破坏性变更）
- [ ] 破坏性变更（会导致现有功能无法正常工作的修复或功能）
- [ ] 文档更新
- [ ] 性能改进
- [ ] 代码重构
- [ ] CI/CD 改进

## 测试

- [x] 我已经在本地测试了这些更改
- [x] 我已经添加了证明我的修复有效或我的功能工作的测试
- [x] 新的和现有的单元测试在我的更改下都能通过
- [x] 我已经检查了代码能够无错误地构建

## 截图（如果适用）

添加截图来帮助解释你的更改。

## 检查清单

- [x] 我的代码遵循此项目的代码风格
- [x] 我已经对自己的代码进行了自我审查
- [x] 我已经对代码进行了注释，特别是在难以理解的地方
- [x] 我已经对文档进行了相应的更改
- [x] 我的更改没有产生新的警告
- [x] 我已经添加了证明我的修复有效或我的功能工作的测试
- [x] 新的和现有的单元测试在我的更改下都能通过

## 代码审查检查清单（供审查者使用）

- [x] 代码可读且有良好的文档
- [x] 更改经过了适当的测试
- [ ] 没有明显的性能问题
- [x] 已解决安全考虑
- [x] 破坏性变更已得到适当记录

## 附加说明

无
