### PR TITLE
fix: resolve next/font not loading for turbopack on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "fumadocs-mdx": "^12.0.3",
     "fumadocs-twoslash": "^3.1.8",
     "fumadocs-ui": "^15.8.5",
+    "geist": "^1.5.1",
     "hast-util-to-jsx-runtime": "^2.3.6",
     "input-otp": "^1.4.2",
     "katex": "^0.16.25",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       fumadocs-ui:
         specifier: ^15.8.5
         version: 15.8.5(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(lucide-react@0.545.0(react@19.1.0))(next@15.5.4(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.16)
+      geist:
+        specifier: ^1.5.1
+        version: 1.5.1(next@15.5.4(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       hast-util-to-jsx-runtime:
         specifier: ^2.3.6
         version: 2.3.6
@@ -5065,6 +5068,11 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  geist@1.5.1:
+    resolution: {integrity: sha512-mAHZxIsL2o3ZITFaBVFBnwyDOw+zNLYum6A6nIjpzCGIO8QtC3V76XF2RnZTyLx1wlDTmMDy8jg3Ib52MIjGvQ==}
+    peerDependencies:
+      next: '>=13.2.0'
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -13254,6 +13262,10 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  geist@1.5.1(next@15.5.4(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
+    dependencies:
+      next: 15.5.4(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   generator-function@2.0.1: {}
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,19 +1,10 @@
 import { RootProvider } from "fumadocs-ui/provider";
+import { GeistMono } from "geist/font/mono";
+import { GeistSans } from "geist/font/sans";
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 
 import { ThemeProvider } from "@/components/common/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Nomad - Your Travel Companion",
@@ -28,7 +19,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${GeistSans.variable} ${GeistMono.variable} antialiased`}
         suppressHydrationWarning
       >
         <ThemeProvider


### PR DESCRIPTION
## 描述

使用 `geist` 代替原本的 `next/font` ，解决开启 `--turbopack` 参数在 Windows 平台上无法正确加载字体的问题。

## 相关问题

Closes #35

## 变更类型

- [x] Bug 修复（不会破坏现有功能的非破坏性变更）
- [ ] 新功能（添加功能的非破坏性变更）
- [ ] 破坏性变更（会导致现有功能无法正常工作的修复或功能）
- [ ] 文档更新
- [ ] 性能改进
- [ ] 代码重构
- [ ] CI/CD 改进

## 测试

- [ ] 我已经在本地测试了这些更改
- [ ] 我已经添加了证明我的修复有效或我的功能工作的测试
- [ ] 新的和现有的单元测试在我的更改下都能通过
- [ ] 我已经检查了代码能够无错误地构建

## 截图（如果适用）

无

## 检查清单

- [ ] 我的代码遵循此项目的代码风格
- [ ] 我已经对自己的代码进行了自我审查
- [ ] 我已经对代码进行了注释，特别是在难以理解的地方
- [ ] 我已经对文档进行了相应的更改
- [ ] 我的更改没有产生新的警告
- [ ] 我已经添加了证明我的修复有效或我的功能工作的测试
- [ ] 新的和现有的单元测试在我的更改下都能通过

## 代码审查检查清单（供审查者使用）

- [ ] 代码可读且有良好的文档
- [ ] 更改经过了适当的测试
- [ ] 没有明显的性能问题
- [ ] 已解决安全考虑
- [ ] 破坏性变更已得到适当记录

## 附加说明

暂无
