### PR TITLE
fix(ci): add explicit read permission for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: PR Build Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ukeSJTU/nomad/security/code-scanning/1](https://github.com/ukeSJTU/nomad/security/code-scanning/1)

To address this issue, it is recommended to explicitly add the `permissions:` block at the job or workflow root, setting the lowest privileges necessary—ideally only `contents: read` for the build/check steps shown. Since the workflow does not perform write operations to the repository, interact with pull requests, or update issues, `contents: read` is sufficient. The fix can be applied either at the root of the YAML file (affecting all jobs), or within the specific `build` job. The best option is to add a root-level `permissions:` block, just after the `name:` declaration and before `on:`, so all jobs inherit these restricted permissions unless otherwise specified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
