### PR TITLE
feat: add user info management page

### DIFF
--- a/auth-schema.ts
+++ b/auth-schema.ts
@@ -1,4 +1,6 @@
-import { boolean, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { boolean, date, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+import { genderEnum } from "./src/lib/schema/passengers";
 
 export const user = pgTable("user", {
   id: text("id").primaryKey(),
@@ -13,6 +15,10 @@ export const user = pgTable("user", {
     .notNull(),
   phoneNumber: text("phone_number").unique(),
   phoneNumberVerified: boolean("phone_number_verified"),
+  // User profile fields
+  nickname: text("nickname"),
+  gender: genderEnum("gender"),
+  birthday: date("birthday"),
 });
 
 export const session = pgTable("session", {

--- a/auth-schema.ts
+++ b/auth-schema.ts
@@ -1,6 +1,6 @@
 import { boolean, date, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 
-import { genderEnum } from "./src/lib/schema/passengers";
+import { genderEnum } from "@/lib/schema/enums";
 
 export const user = pgTable("user", {
   id: text("id").primaryKey(),

--- a/src/app/(frontend)/home/info/page.tsx
+++ b/src/app/(frontend)/home/info/page.tsx
@@ -68,18 +68,30 @@ export default async function UserInfoPage() {
                   邮箱
                 </label>
                 <div className="flex items-center gap-2">
-                  <span className="text-sm text-gray-900">
-                    {userData.email}
-                  </span>
-                  {userData.emailVerified && (
-                    <span className="text-xs text-green-600">(已验证)</span>
+                  {userData.email && userData.emailVerified ? (
+                    <>
+                      <span className="text-sm text-gray-900">
+                        {userData.email}
+                      </span>
+                      <span className="text-xs text-green-600">(已验证)</span>
+                      <Link
+                        href="/home/info/email"
+                        className="text-sm text-blue-600 hover:underline"
+                      >
+                        修改
+                      </Link>
+                    </>
+                  ) : (
+                    <>
+                      <span className="text-sm text-gray-500">未填写</span>
+                      <Link
+                        href="/home/info/email"
+                        className="text-sm text-blue-600 hover:underline"
+                      >
+                        验证
+                      </Link>
+                    </>
                   )}
-                  <Link
-                    href="/home/info/email"
-                    className="text-sm text-blue-600 hover:underline"
-                  >
-                    修改
-                  </Link>
                 </div>
               </div>
 
@@ -89,14 +101,12 @@ export default async function UserInfoPage() {
                   手机号
                 </label>
                 <div className="flex items-center gap-2">
-                  {userData.phoneNumber ? (
+                  {userData.phoneNumber && userData.phoneNumberVerified ? (
                     <>
                       <span className="text-sm text-gray-900">
                         {userData.phoneNumber}
                       </span>
-                      {userData.phoneNumberVerified && (
-                        <span className="text-xs text-green-600">(已验证)</span>
-                      )}
+                      <span className="text-xs text-green-600">(已验证)</span>
                       <Link
                         href="/home/info/phone"
                         className="text-sm text-blue-600 hover:underline"

--- a/src/app/(frontend)/home/info/page.tsx
+++ b/src/app/(frontend)/home/info/page.tsx
@@ -1,0 +1,55 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { UserInfoForm } from "@/components/user";
+import { auth } from "@/lib/auth";
+import { getUserInfo } from "@/lib/queries";
+
+/**
+ * User Information Page (Server Component)
+ *
+ * Displays and allows editing of the current user's personal information.
+ * This is a Server Component that handles authentication and data fetching,
+ * then renders the UserInfoForm client component for user interaction.
+ *
+ * Features:
+ * - Authentication check with redirect to sign-in
+ * - Server-side data fetching with data masking for sensitive fields
+ * - View/edit modes for user information
+ * - Update functionality via Server Actions
+ */
+export default async function UserInfoPage() {
+  // Check authentication
+  const headersList = await headers();
+  const session = await auth.api.getSession({
+    headers: headersList,
+  });
+
+  // Redirect to sign-in if not authenticated
+  if (!session?.user?.id) {
+    redirect("/auth/sign-in");
+  }
+
+  // Fetch user information (with masked sensitive data)
+  const userData = await getUserInfo(session.user.id);
+
+  // Handle case where user data is not found (should not happen for authenticated users)
+  if (!userData) {
+    redirect("/auth/sign-in");
+  }
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      <div className="max-w-4xl mx-auto">
+        {/* Page Header */}
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold mb-2">个人信息</h1>
+          <p className="text-muted-foreground">查看和管理您的个人信息</p>
+        </div>
+
+        {/* User Info Form Component */}
+        <UserInfoForm userData={userData} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(frontend)/home/info/page.tsx
+++ b/src/app/(frontend)/home/info/page.tsx
@@ -1,6 +1,8 @@
 import { headers } from "next/headers";
+import Link from "next/link";
 import { redirect } from "next/navigation";
 
+import { Separator } from "@/components/ui/separator";
 import { UserInfoForm } from "@/components/user";
 import { auth } from "@/lib/auth";
 import { getUserInfo } from "@/lib/queries";
@@ -47,8 +49,77 @@ export default async function UserInfoPage() {
           <p className="text-muted-foreground">查看和管理您的个人信息</p>
         </div>
 
-        {/* User Info Form Component */}
-        <UserInfoForm userData={userData} />
+        <div className="space-y-6">
+          {/* User Info Form Component */}
+          <UserInfoForm userData={userData} />
+
+          {/* Account Security Section */}
+          <div className="space-y-6 bg-white p-6 rounded-lg border">
+            <div className="flex items-center justify-between">
+              <h2 className="text-xl font-semibold text-gray-900">账号安全</h2>
+            </div>
+
+            <Separator />
+
+            <div className="space-y-4">
+              {/* Email */}
+              <div className="grid grid-cols-[150px_1fr] items-start gap-4">
+                <label className="pt-1 text-sm font-medium text-gray-600">
+                  邮箱
+                </label>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-gray-900">
+                    {userData.email}
+                  </span>
+                  {userData.emailVerified && (
+                    <span className="text-xs text-green-600">(已验证)</span>
+                  )}
+                  <Link
+                    href="/home/info/email"
+                    className="text-sm text-blue-600 hover:underline"
+                  >
+                    修改
+                  </Link>
+                </div>
+              </div>
+
+              {/* Phone Number */}
+              <div className="grid grid-cols-[150px_1fr] items-start gap-4">
+                <label className="pt-1 text-sm font-medium text-gray-600">
+                  手机号
+                </label>
+                <div className="flex items-center gap-2">
+                  {userData.phoneNumber ? (
+                    <>
+                      <span className="text-sm text-gray-900">
+                        {userData.phoneNumber}
+                      </span>
+                      {userData.phoneNumberVerified && (
+                        <span className="text-xs text-green-600">(已验证)</span>
+                      )}
+                      <Link
+                        href="/home/info/phone"
+                        className="text-sm text-blue-600 hover:underline"
+                      >
+                        修改
+                      </Link>
+                    </>
+                  ) : (
+                    <>
+                      <span className="text-sm text-gray-500">未填写</span>
+                      <Link
+                        href="/home/info/phone"
+                        className="text-sm text-blue-600 hover:underline"
+                      >
+                        验证
+                      </Link>
+                    </>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/user/index.ts
+++ b/src/components/user/index.ts
@@ -1,0 +1,1 @@
+export * from "./user-info-form";

--- a/src/components/user/user-info-form.tsx
+++ b/src/components/user/user-info-form.tsx
@@ -33,9 +33,9 @@ interface UserInfoFormProps {
 }
 
 const genderLabels = {
-  male: "Male",
-  female: "Female",
-  other: "Other",
+  male: "男",
+  female: "女",
+  other: "其他",
 };
 
 export function UserInfoForm({ userData }: UserInfoFormProps) {
@@ -66,11 +66,11 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
       } else {
         // Show error message
         console.error("Update failed:", result.error);
-        alert(result.error || "Failed to update user information");
+        alert(result.error || "更新用户信息失败");
       }
     } catch (error) {
       console.error("Failed to update user info:", error);
-      alert("Failed to update user information");
+      alert("更新用户信息失败");
     } finally {
       setIsLoading(false);
     }
@@ -91,9 +91,7 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
     return (
       <div className="space-y-6 bg-white p-6 rounded-lg border">
         <div className="flex items-center justify-between">
-          <h2 className="text-xl font-semibold text-gray-900">
-            Edit Personal Information
-          </h2>
+          <h2 className="text-xl font-semibold text-gray-900">编辑个人信息</h2>
         </div>
 
         <Separator />
@@ -109,9 +107,9 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
               name="nickname"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Nickname</FormLabel>
+                  <FormLabel>昵称</FormLabel>
                   <FormControl>
-                    <Input {...field} placeholder="Enter your nickname" />
+                    <Input {...field} placeholder="请输入昵称" />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -124,9 +122,9 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
               name="name"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Name</FormLabel>
+                  <FormLabel>姓名</FormLabel>
                   <FormControl>
-                    <Input {...field} placeholder="Enter your name" />
+                    <Input {...field} placeholder="请输入姓名" />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -139,7 +137,7 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
               name="gender"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Gender</FormLabel>
+                  <FormLabel>性别</FormLabel>
                   <FormControl>
                     <RadioGroup
                       onValueChange={field.onChange}
@@ -149,19 +147,19 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
                       <div className="flex items-center space-x-2">
                         <RadioGroupItem value="male" id="male" />
                         <label htmlFor="male" className="cursor-pointer">
-                          Male
+                          男
                         </label>
                       </div>
                       <div className="flex items-center space-x-2">
                         <RadioGroupItem value="female" id="female" />
                         <label htmlFor="female" className="cursor-pointer">
-                          Female
+                          女
                         </label>
                       </div>
                       <div className="flex items-center space-x-2">
                         <RadioGroupItem value="other" id="other" />
                         <label htmlFor="other" className="cursor-pointer">
-                          Other
+                          其他
                         </label>
                       </div>
                     </RadioGroup>
@@ -177,7 +175,7 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
               name="birthday"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Birthday</FormLabel>
+                  <FormLabel>生日</FormLabel>
                   <FormControl>
                     <Input {...field} type="date" placeholder="yyyy-mm-dd" />
                   </FormControl>
@@ -189,7 +187,7 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
             {/* Action Buttons */}
             <div className="flex gap-3 pt-4">
               <Button type="submit" disabled={isLoading}>
-                {isLoading ? "Saving..." : "Save"}
+                {isLoading ? "保存中..." : "保存"}
               </Button>
               <Button
                 type="button"
@@ -197,7 +195,7 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
                 onClick={handleCancel}
                 disabled={isLoading}
               >
-                Cancel
+                取消
               </Button>
             </div>
           </form>
@@ -211,10 +209,8 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
     <>
       <div className="space-y-6 bg-white p-6 rounded-lg border">
         <div className="flex items-center justify-between">
-          <h2 className="text-xl font-semibold text-gray-900">
-            Personal Information
-          </h2>
-          <Button onClick={() => setIsEditMode(true)}>Edit</Button>
+          <h2 className="text-xl font-semibold text-gray-900">个人信息</h2>
+          <Button onClick={() => setIsEditMode(true)}>编辑</Button>
         </div>
 
         <Separator />
@@ -223,17 +219,17 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
           {/* Nickname */}
           <div className="grid grid-cols-[150px_1fr] items-start gap-4">
             <label className="pt-1 text-sm font-medium text-gray-600">
-              Nickname
+              昵称
             </label>
             <div className="text-sm text-gray-900">
-              {userData.nickname || "Not set"}
+              {userData.nickname || "未设置"}
             </div>
           </div>
 
           {/* Name */}
           <div className="grid grid-cols-[150px_1fr] items-start gap-4">
             <label className="pt-1 text-sm font-medium text-gray-600">
-              Name
+              姓名
             </label>
             <div className="text-sm text-gray-900">{userData.name}</div>
           </div>
@@ -241,35 +237,35 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
           {/* Gender */}
           <div className="grid grid-cols-[150px_1fr] items-start gap-4">
             <label className="pt-1 text-sm font-medium text-gray-600">
-              Gender
+              性别
             </label>
             <div className="text-sm text-gray-900">
-              {userData.gender ? genderLabels[userData.gender] : "Not set"}
+              {userData.gender ? genderLabels[userData.gender] : "未设置"}
             </div>
           </div>
 
           {/* Birthday */}
           <div className="grid grid-cols-[150px_1fr] items-start gap-4">
             <label className="pt-1 text-sm font-medium text-gray-600">
-              Birthday
+              生日
             </label>
             <div className="text-sm text-gray-900">
-              {userData.birthday || "Not set"}
+              {userData.birthday || "未设置"}
             </div>
           </div>
 
           {/* Email */}
           <div className="grid grid-cols-[150px_1fr] items-start gap-4">
             <label className="pt-1 text-sm font-medium text-gray-600">
-              Email
+              邮箱
             </label>
             <div className="flex items-center gap-2">
               <span className="text-sm text-gray-900">{userData.email}</span>
               {userData.emailVerified && (
-                <span className="text-xs text-green-600">(Verified)</span>
+                <span className="text-xs text-green-600">(已验证)</span>
               )}
               <a href="#" className="text-sm text-blue-600 hover:underline">
-                Modify
+                修改
               </a>
             </div>
           </div>
@@ -277,7 +273,7 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
           {/* Phone Number */}
           <div className="grid grid-cols-[150px_1fr] items-start gap-4">
             <label className="pt-1 text-sm font-medium text-gray-600">
-              Phone Number
+              手机号
             </label>
             <div className="flex items-center gap-2">
               {userData.phoneNumber ? (
@@ -286,17 +282,17 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
                     {userData.phoneNumber}
                   </span>
                   {userData.phoneNumberVerified && (
-                    <span className="text-xs text-green-600">(Verified)</span>
+                    <span className="text-xs text-green-600">(已验证)</span>
                   )}
                   <a href="#" className="text-sm text-blue-600 hover:underline">
-                    Modify
+                    修改
                   </a>
                 </>
               ) : (
                 <>
-                  <span className="text-sm text-gray-500">Not set</span>
+                  <span className="text-sm text-gray-500">未填写</span>
                   <a href="#" className="text-sm text-blue-600 hover:underline">
-                    Verify
+                    验证
                   </a>
                 </>
               )}
@@ -309,13 +305,11 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
       <Dialog open={showSuccessDialog} onOpenChange={setShowSuccessDialog}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Success</DialogTitle>
-            <DialogDescription>
-              Your personal information has been updated successfully.
-            </DialogDescription>
+            <DialogTitle>保存成功</DialogTitle>
+            <DialogDescription>您的个人信息已成功更新。</DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button onClick={() => setShowSuccessDialog(false)}>OK</Button>
+            <Button onClick={() => setShowSuccessDialog(false)}>确定</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/components/user/user-info-form.tsx
+++ b/src/components/user/user-info-form.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useActionState, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import { Button } from "@/components/ui/button";
@@ -24,7 +25,10 @@ import {
 import { Input } from "@/components/ui/input";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Separator } from "@/components/ui/separator";
-import { updateUserInfoAction } from "@/lib/actions";
+import {
+  updateUserInfoAction,
+  type UpdateUserInfoActionState,
+} from "@/lib/actions";
 import type { UserInfo } from "@/lib/queries/user";
 import { type UserInfoUpdateData, userInfoUpdateSchema } from "@/types/user";
 
@@ -39,9 +43,15 @@ const genderLabels = {
 };
 
 export function UserInfoForm({ userData }: UserInfoFormProps) {
+  const router = useRouter();
   const [isEditMode, setIsEditMode] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
   const [showSuccessDialog, setShowSuccessDialog] = useState(false);
+
+  // Use useActionState for better form handling
+  const [state, formAction, isPending] = useActionState<
+    UpdateUserInfoActionState | null,
+    FormData
+  >(updateUserInfoAction, null);
 
   const form = useForm<UserInfoUpdateData>({
     resolver: zodResolver(userInfoUpdateSchema),
@@ -53,27 +63,26 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
     },
   });
 
-  const handleSubmit = async (data: UserInfoUpdateData) => {
-    setIsLoading(true);
-    try {
-      const result = await updateUserInfoAction(data);
-
-      if (result.success) {
-        setShowSuccessDialog(true);
-        setIsEditMode(false);
-        // Refresh the page to show updated data
-        window.location.reload();
-      } else {
-        // Show error message
-        console.error("Update failed:", result.error);
-        alert(result.error || "更新用户信息失败");
-      }
-    } catch (error) {
-      console.error("Failed to update user info:", error);
-      alert("更新用户信息失败");
-    } finally {
-      setIsLoading(false);
+  // Handle successful submission
+  useEffect(() => {
+    if (state?.success) {
+      setShowSuccessDialog(true);
+      setIsEditMode(false);
+      // Refresh the page data without full reload
+      router.refresh();
     }
+  }, [state, router]);
+
+  const handleSubmit = (data: UserInfoUpdateData) => {
+    // Convert data to FormData for useActionState
+    const formData = new FormData();
+    if (data.nickname !== undefined) formData.append("nickname", data.nickname);
+    if (data.name !== undefined) formData.append("name", data.name);
+    if (data.gender !== undefined) formData.append("gender", data.gender);
+    if (data.birthday !== undefined) formData.append("birthday", data.birthday);
+
+    // Submit via formAction
+    formAction(formData);
   };
 
   const handleCancel = () => {
@@ -184,16 +193,23 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
               )}
             />
 
+            {/* Error Message */}
+            {state?.error && (
+              <div className="rounded-md bg-red-50 p-4">
+                <p className="text-sm text-red-800">{state.error}</p>
+              </div>
+            )}
+
             {/* Action Buttons */}
             <div className="flex gap-3 pt-4">
-              <Button type="submit" disabled={isLoading}>
-                {isLoading ? "保存中..." : "保存"}
+              <Button type="submit" disabled={isPending}>
+                {isPending ? "保存中..." : "保存"}
               </Button>
               <Button
                 type="button"
                 variant="outline"
                 onClick={handleCancel}
-                disabled={isLoading}
+                disabled={isPending}
               >
                 取消
               </Button>

--- a/src/components/user/user-info-form.tsx
+++ b/src/components/user/user-info-form.tsx
@@ -269,51 +269,6 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
               {userData.birthday || "未设置"}
             </div>
           </div>
-
-          {/* Email */}
-          <div className="grid grid-cols-[150px_1fr] items-start gap-4">
-            <label className="pt-1 text-sm font-medium text-gray-600">
-              邮箱
-            </label>
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-gray-900">{userData.email}</span>
-              {userData.emailVerified && (
-                <span className="text-xs text-green-600">(已验证)</span>
-              )}
-              <a href="#" className="text-sm text-blue-600 hover:underline">
-                修改
-              </a>
-            </div>
-          </div>
-
-          {/* Phone Number */}
-          <div className="grid grid-cols-[150px_1fr] items-start gap-4">
-            <label className="pt-1 text-sm font-medium text-gray-600">
-              手机号
-            </label>
-            <div className="flex items-center gap-2">
-              {userData.phoneNumber ? (
-                <>
-                  <span className="text-sm text-gray-900">
-                    {userData.phoneNumber}
-                  </span>
-                  {userData.phoneNumberVerified && (
-                    <span className="text-xs text-green-600">(已验证)</span>
-                  )}
-                  <a href="#" className="text-sm text-blue-600 hover:underline">
-                    修改
-                  </a>
-                </>
-              ) : (
-                <>
-                  <span className="text-sm text-gray-500">未填写</span>
-                  <a href="#" className="text-sm text-blue-600 hover:underline">
-                    验证
-                  </a>
-                </>
-              )}
-            </div>
-          </div>
         </div>
       </div>
 

--- a/src/components/user/user-info-form.tsx
+++ b/src/components/user/user-info-form.tsx
@@ -153,24 +153,17 @@ export function UserInfoForm({ userData }: UserInfoFormProps) {
                       value={field.value}
                       className="flex gap-4"
                     >
-                      <div className="flex items-center space-x-2">
-                        <RadioGroupItem value="male" id="male" />
-                        <label htmlFor="male" className="cursor-pointer">
-                          男
-                        </label>
-                      </div>
-                      <div className="flex items-center space-x-2">
-                        <RadioGroupItem value="female" id="female" />
-                        <label htmlFor="female" className="cursor-pointer">
-                          女
-                        </label>
-                      </div>
-                      <div className="flex items-center space-x-2">
-                        <RadioGroupItem value="other" id="other" />
-                        <label htmlFor="other" className="cursor-pointer">
-                          其他
-                        </label>
-                      </div>
+                      {Object.entries(genderLabels).map(([value, label]) => (
+                        <div
+                          key={value}
+                          className="flex items-center space-x-2"
+                        >
+                          <RadioGroupItem value={value} id={value} />
+                          <label htmlFor={value} className="cursor-pointer">
+                            {label}
+                          </label>
+                        </div>
+                      ))}
                     </RadioGroup>
                   </FormControl>
                   <FormMessage />

--- a/src/components/user/user-info-form.tsx
+++ b/src/components/user/user-info-form.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Separator } from "@/components/ui/separator";
+import { updateUserInfoAction } from "@/lib/actions";
+import type { UserInfo } from "@/lib/queries/user";
+import { type UserInfoUpdateData, userInfoUpdateSchema } from "@/types/user";
+
+interface UserInfoFormProps {
+  userData: UserInfo;
+}
+
+const genderLabels = {
+  male: "Male",
+  female: "Female",
+  other: "Other",
+};
+
+export function UserInfoForm({ userData }: UserInfoFormProps) {
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [showSuccessDialog, setShowSuccessDialog] = useState(false);
+
+  const form = useForm<UserInfoUpdateData>({
+    resolver: zodResolver(userInfoUpdateSchema),
+    defaultValues: {
+      nickname: userData.nickname || "",
+      name: userData.name || "",
+      gender: userData.gender || undefined,
+      birthday: userData.birthday || "",
+    },
+  });
+
+  const handleSubmit = async (data: UserInfoUpdateData) => {
+    setIsLoading(true);
+    try {
+      const result = await updateUserInfoAction(data);
+
+      if (result.success) {
+        setShowSuccessDialog(true);
+        setIsEditMode(false);
+        // Refresh the page to show updated data
+        window.location.reload();
+      } else {
+        // Show error message
+        console.error("Update failed:", result.error);
+        alert(result.error || "Failed to update user information");
+      }
+    } catch (error) {
+      console.error("Failed to update user info:", error);
+      alert("Failed to update user information");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setIsEditMode(false);
+    // Reset form to original values
+    form.reset({
+      nickname: userData.nickname || "",
+      name: userData.name || "",
+      gender: userData.gender || undefined,
+      birthday: userData.birthday || "",
+    });
+  };
+
+  if (isEditMode) {
+    return (
+      <div className="space-y-6 bg-white p-6 rounded-lg border">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-gray-900">
+            Edit Personal Information
+          </h2>
+        </div>
+
+        <Separator />
+
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleSubmit)}
+            className="space-y-6"
+          >
+            {/* Nickname */}
+            <FormField
+              control={form.control}
+              name="nickname"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nickname</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder="Enter your nickname" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Name */}
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder="Enter your name" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Gender */}
+            <FormField
+              control={form.control}
+              name="gender"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Gender</FormLabel>
+                  <FormControl>
+                    <RadioGroup
+                      onValueChange={field.onChange}
+                      value={field.value}
+                      className="flex gap-4"
+                    >
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem value="male" id="male" />
+                        <label htmlFor="male" className="cursor-pointer">
+                          Male
+                        </label>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem value="female" id="female" />
+                        <label htmlFor="female" className="cursor-pointer">
+                          Female
+                        </label>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem value="other" id="other" />
+                        <label htmlFor="other" className="cursor-pointer">
+                          Other
+                        </label>
+                      </div>
+                    </RadioGroup>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Birthday */}
+            <FormField
+              control={form.control}
+              name="birthday"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Birthday</FormLabel>
+                  <FormControl>
+                    <Input {...field} type="date" placeholder="yyyy-mm-dd" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Action Buttons */}
+            <div className="flex gap-3 pt-4">
+              <Button type="submit" disabled={isLoading}>
+                {isLoading ? "Saving..." : "Save"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleCancel}
+                disabled={isLoading}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </div>
+    );
+  }
+
+  // View Mode
+  return (
+    <>
+      <div className="space-y-6 bg-white p-6 rounded-lg border">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-gray-900">
+            Personal Information
+          </h2>
+          <Button onClick={() => setIsEditMode(true)}>Edit</Button>
+        </div>
+
+        <Separator />
+
+        <div className="space-y-4">
+          {/* Nickname */}
+          <div className="grid grid-cols-[150px_1fr] items-start gap-4">
+            <label className="pt-1 text-sm font-medium text-gray-600">
+              Nickname
+            </label>
+            <div className="text-sm text-gray-900">
+              {userData.nickname || "Not set"}
+            </div>
+          </div>
+
+          {/* Name */}
+          <div className="grid grid-cols-[150px_1fr] items-start gap-4">
+            <label className="pt-1 text-sm font-medium text-gray-600">
+              Name
+            </label>
+            <div className="text-sm text-gray-900">{userData.name}</div>
+          </div>
+
+          {/* Gender */}
+          <div className="grid grid-cols-[150px_1fr] items-start gap-4">
+            <label className="pt-1 text-sm font-medium text-gray-600">
+              Gender
+            </label>
+            <div className="text-sm text-gray-900">
+              {userData.gender ? genderLabels[userData.gender] : "Not set"}
+            </div>
+          </div>
+
+          {/* Birthday */}
+          <div className="grid grid-cols-[150px_1fr] items-start gap-4">
+            <label className="pt-1 text-sm font-medium text-gray-600">
+              Birthday
+            </label>
+            <div className="text-sm text-gray-900">
+              {userData.birthday || "Not set"}
+            </div>
+          </div>
+
+          {/* Email */}
+          <div className="grid grid-cols-[150px_1fr] items-start gap-4">
+            <label className="pt-1 text-sm font-medium text-gray-600">
+              Email
+            </label>
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-900">{userData.email}</span>
+              {userData.emailVerified && (
+                <span className="text-xs text-green-600">(Verified)</span>
+              )}
+              <a href="#" className="text-sm text-blue-600 hover:underline">
+                Modify
+              </a>
+            </div>
+          </div>
+
+          {/* Phone Number */}
+          <div className="grid grid-cols-[150px_1fr] items-start gap-4">
+            <label className="pt-1 text-sm font-medium text-gray-600">
+              Phone Number
+            </label>
+            <div className="flex items-center gap-2">
+              {userData.phoneNumber ? (
+                <>
+                  <span className="text-sm text-gray-900">
+                    {userData.phoneNumber}
+                  </span>
+                  {userData.phoneNumberVerified && (
+                    <span className="text-xs text-green-600">(Verified)</span>
+                  )}
+                  <a href="#" className="text-sm text-blue-600 hover:underline">
+                    Modify
+                  </a>
+                </>
+              ) : (
+                <>
+                  <span className="text-sm text-gray-500">Not set</span>
+                  <a href="#" className="text-sm text-blue-600 hover:underline">
+                    Verify
+                  </a>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Success Dialog */}
+      <Dialog open={showSuccessDialog} onOpenChange={setShowSuccessDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Success</DialogTitle>
+            <DialogDescription>
+              Your personal information has been updated successfully.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button onClick={() => setShowSuccessDialog(false)}>OK</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/lib/actions/index.ts
+++ b/src/lib/actions/index.ts
@@ -1,3 +1,4 @@
 export * from "./auth";
 export * from "./flight-search-history";
 export * from "./passengers";
+export * from "./user";

--- a/src/lib/actions/user.ts
+++ b/src/lib/actions/user.ts
@@ -48,12 +48,7 @@ export async function updateUserInfoAction(
     }
 
     // 2. Convert FormData to object
-    const data = {
-      nickname: formData.get("nickname") as string | undefined,
-      name: formData.get("name") as string | undefined,
-      gender: formData.get("gender") as "male" | "female" | "other" | undefined,
-      birthday: formData.get("birthday") as string | undefined,
-    };
+    const data = Object.fromEntries(formData.entries());
 
     // 3. Validate input data
     const validation = userInfoUpdateSchema.safeParse(data);

--- a/src/lib/actions/user.ts
+++ b/src/lib/actions/user.ts
@@ -1,0 +1,64 @@
+"use server";
+
+import { headers } from "next/headers";
+
+import { auth } from "@/lib/auth";
+import { updateUserInfo } from "@/lib/services/user";
+import { userInfoUpdateSchema } from "@/types/user";
+
+/**
+ * Server action to update user profile information
+ *
+ * This is a thin controller that:
+ * 1. Handles authentication (Next.js specific)
+ * 2. Validates input data
+ * 3. Calls the service layer for business logic
+ * 4. Formats the response
+ *
+ * All fields are optional - only provided fields will be updated
+ *
+ * @param formData - User info data to update
+ * @returns Result object with success status and message/error
+ */
+export async function updateUserInfoAction(formData: unknown) {
+  try {
+    // 1. Verify authentication (framework-specific)
+    const headersList = await headers();
+    const session = await auth.api.getSession({
+      headers: headersList,
+    });
+
+    if (!session?.user?.id) {
+      return {
+        success: false,
+        error: "Authentication required. Please log in first.",
+      };
+    }
+
+    // 2. Validate input data
+    const validation = userInfoUpdateSchema.safeParse(formData);
+
+    if (!validation.success) {
+      return {
+        success: false,
+        error: "Invalid input data",
+        fieldErrors: validation.error.flatten().fieldErrors,
+      };
+    }
+
+    // 3. Call service layer for business logic
+    const result = await updateUserInfo(session.user.id, validation.data);
+
+    // 4. Return the result
+    return result;
+  } catch (error) {
+    console.error("Failed to update user info:", error);
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Failed to update user information",
+    };
+  }
+}

--- a/src/lib/actions/user.ts
+++ b/src/lib/actions/user.ts
@@ -6,8 +6,16 @@ import { auth } from "@/lib/auth";
 import { updateUserInfo } from "@/lib/services/user";
 import { userInfoUpdateSchema } from "@/types/user";
 
+// Action state type for useActionState
+export interface UpdateUserInfoActionState {
+  success: boolean;
+  message?: string;
+  error?: string;
+  fieldErrors?: Record<string, string[] | undefined>;
+}
+
 /**
- * Server action to update user profile information
+ * Update user information action (compatible with useActionState)
  *
  * This is a thin controller that:
  * 1. Handles authentication (Next.js specific)
@@ -17,10 +25,14 @@ import { userInfoUpdateSchema } from "@/types/user";
  *
  * All fields are optional - only provided fields will be updated
  *
- * @param formData - User info data to update
- * @returns Result object with success status and message/error
+ * @param prevState - Previous state (required by useActionState)
+ * @param formData - Form data from the form submission
+ * @returns Action state with success status and message/error
  */
-export async function updateUserInfoAction(formData: unknown) {
+export async function updateUserInfoAction(
+  prevState: UpdateUserInfoActionState | null,
+  formData: FormData
+): Promise<UpdateUserInfoActionState> {
   try {
     // 1. Verify authentication (framework-specific)
     const headersList = await headers();
@@ -31,34 +43,49 @@ export async function updateUserInfoAction(formData: unknown) {
     if (!session?.user?.id) {
       return {
         success: false,
-        error: "Authentication required. Please log in first.",
+        error: "需要登录。请先登录。",
       };
     }
 
-    // 2. Validate input data
-    const validation = userInfoUpdateSchema.safeParse(formData);
+    // 2. Convert FormData to object
+    const data = {
+      nickname: formData.get("nickname") as string | undefined,
+      name: formData.get("name") as string | undefined,
+      gender: formData.get("gender") as "male" | "female" | "other" | undefined,
+      birthday: formData.get("birthday") as string | undefined,
+    };
+
+    // 3. Validate input data
+    const validation = userInfoUpdateSchema.safeParse(data);
 
     if (!validation.success) {
       return {
         success: false,
-        error: "Invalid input data",
+        error: "输入数据无效",
         fieldErrors: validation.error.flatten().fieldErrors,
       };
     }
 
-    // 3. Call service layer for business logic
+    // 4. Call service layer for business logic
     const result = await updateUserInfo(session.user.id, validation.data);
 
-    // 4. Return the result
-    return result;
+    // 5. Return the result
+    if (result.success) {
+      return {
+        success: true,
+        message: result.message || "个人信息更新成功",
+      };
+    } else {
+      return {
+        success: false,
+        error: result.error || "更新用户信息失败",
+      };
+    }
   } catch (error) {
     console.error("Failed to update user info:", error);
     return {
       success: false,
-      error:
-        error instanceof Error
-          ? error.message
-          : "Failed to update user information",
+      error: error instanceof Error ? error.message : "更新用户信息失败",
     };
   }
 }

--- a/src/lib/actions/user.ts
+++ b/src/lib/actions/user.ts
@@ -30,7 +30,7 @@ export interface UpdateUserInfoActionState {
  * @returns Action state with success status and message/error
  */
 export async function updateUserInfoAction(
-  prevState: UpdateUserInfoActionState | null,
+  _prevState: UpdateUserInfoActionState | null,
   formData: FormData
 ): Promise<UpdateUserInfoActionState> {
   try {

--- a/src/lib/queries/index.ts
+++ b/src/lib/queries/index.ts
@@ -1,3 +1,4 @@
 export * from "./flight-search-history";
 export * from "./flights";
 export * from "./passengers";
+export * from "./user";

--- a/src/lib/queries/user.ts
+++ b/src/lib/queries/user.ts
@@ -1,0 +1,62 @@
+import { eq } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import { user } from "@/lib/schema";
+import { maskEmail, maskPhoneNumber } from "@/utils/mask-data";
+
+/**
+ * User info data structure for frontend display
+ */
+export interface UserInfo {
+  id: string;
+  name: string;
+  nickname: string | null;
+  email: string;
+  emailVerified: boolean;
+  phoneNumber: string | null;
+  phoneNumberVerified: boolean;
+  gender: "male" | "female" | "other" | null;
+  birthday: string | null;
+  image: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Get user information by user ID
+ *
+ * This function fetches user data from the database and applies
+ * data masking for sensitive fields (phone, email).
+ *
+ * @param userId - The ID of the user to fetch
+ * @returns User info with masked sensitive data, or null if user not found
+ */
+export async function getUserInfo(userId: string): Promise<UserInfo | null> {
+  const [result] = await db.select().from(user).where(eq(user.id, userId));
+
+  if (!result) {
+    return null;
+  }
+
+  // Apply data masking for sensitive fields
+  const maskedEmail = maskEmail(result.email);
+  const maskedPhone = result.phoneNumber
+    ? maskPhoneNumber(result.phoneNumber)
+    : null;
+
+  // Convert database result to API format
+  return {
+    id: result.id,
+    name: result.name,
+    nickname: result.nickname,
+    email: maskedEmail,
+    emailVerified: result.emailVerified,
+    phoneNumber: maskedPhone,
+    phoneNumberVerified: result.phoneNumberVerified ?? false,
+    gender: result.gender,
+    birthday: result.birthday,
+    image: result.image,
+    createdAt: result.createdAt.toISOString(),
+    updatedAt: result.updatedAt.toISOString(),
+  };
+}

--- a/src/lib/schema/enums.ts
+++ b/src/lib/schema/enums.ts
@@ -1,0 +1,100 @@
+import { pgEnum } from "drizzle-orm/pg-core";
+
+/**
+ * Enums for Database Schema
+ *
+ * This file contains all enum definitions used across the schema files.
+ * Centralizing enums here prevents circular import issues.
+ */
+
+// ============================================================================
+// PostgreSQL Enums (pgEnum)
+// ============================================================================
+
+/**
+ * Gender enum for passengers
+ */
+export const genderEnum = pgEnum("gender", ["male", "female", "other"]);
+
+/**
+ * Document type enum for passengers
+ */
+export const documentTypeEnum = pgEnum("document_type", [
+  "passport",
+  "id_card",
+  "other",
+]);
+
+// ============================================================================
+// TypeScript Enums and Constants
+// ============================================================================
+
+/**
+ * Trip types for flight searches
+ */
+export const TripType = {
+  ONE_WAY: "one-way",
+  ROUND_TRIP: "round-trip",
+} as const;
+
+export type TripType = (typeof TripType)[keyof typeof TripType];
+
+/**
+ * Seat classes for flights (lowercase - used in search history)
+ */
+export const SeatClass = {
+  ECONOMY: "economy",
+  BUSINESS: "business",
+  FIRST: "first",
+} as const;
+
+export type SeatClass = (typeof SeatClass)[keyof typeof SeatClass];
+
+/**
+ * Flight seat class types (uppercase - used in seat inventory)
+ */
+export const FlightSeatClassType = {
+  ECONOMY: "ECONOMY",
+  BUSINESS: "BUSINESS",
+  FIRST: "FIRST",
+} as const;
+
+export type FlightSeatClassType =
+  (typeof FlightSeatClassType)[keyof typeof FlightSeatClassType];
+
+/**
+ * Continents for international cities
+ */
+export const Continent = {
+  ASIA: "Asia",
+  EUROPE: "Europe",
+  AMERICA: "America",
+  AFRICA: "Africa",
+  OCEANIA: "Oceania",
+} as const;
+
+export type Continent = (typeof Continent)[keyof typeof Continent];
+
+// ============================================================================
+// Helper Arrays (for validation and iteration)
+// ============================================================================
+
+/**
+ * Array of all valid trip types
+ */
+export const TRIP_TYPES = Object.values(TripType);
+
+/**
+ * Array of all valid seat classes
+ */
+export const SEAT_CLASSES = Object.values(SeatClass);
+
+/**
+ * Array of all valid flight seat class types
+ */
+export const FLIGHT_SEAT_CLASS_TYPES = Object.values(FlightSeatClassType);
+
+/**
+ * Array of all valid continents
+ */
+export const CONTINENTS = Object.values(Continent);

--- a/src/lib/schema/index.ts
+++ b/src/lib/schema/index.ts
@@ -2,6 +2,7 @@ export * from "../../../auth-schema";
 export * from "./airlines";
 export * from "./airports";
 export * from "./cities";
+export * from "./enums";
 export * from "./flight-search-history";
 export * from "./flight-seat-classes";
 export * from "./flights";

--- a/src/lib/schema/passengers.test.ts
+++ b/src/lib/schema/passengers.test.ts
@@ -1,10 +1,12 @@
+import { getTableName } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 
-import { documentTypeEnum, genderEnum, passengers } from "./passengers";
+import { documentTypeEnum, genderEnum } from "./enums";
+import { passengers } from "./passengers";
 
 describe("Passengers Schema", () => {
   it("should have correct table name", () => {
-    expect(passengers[Symbol.for("drizzle:Name")]).toBe("passengers");
+    expect(getTableName(passengers)).toBe("passengers");
   });
 
   it("should have all required fields defined", () => {

--- a/src/lib/schema/passengers.ts
+++ b/src/lib/schema/passengers.ts
@@ -14,7 +14,6 @@ import {
   check,
   date,
   index,
-  pgEnum,
   pgTable,
   text,
   timestamp,
@@ -23,16 +22,7 @@ import {
 } from "drizzle-orm/pg-core";
 
 import { user } from "../../../auth-schema";
-
-// Gender enum type
-export const genderEnum = pgEnum("gender", ["male", "female", "other"]);
-
-// Document type enum
-export const documentTypeEnum = pgEnum("document_type", [
-  "passport",
-  "id_card",
-  "other",
-]);
+import { documentTypeEnum, genderEnum } from "./enums";
 
 // All other fields are optional
 export const passengers = pgTable(

--- a/src/lib/services/user.ts
+++ b/src/lib/services/user.ts
@@ -1,0 +1,86 @@
+import { eq } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import { user } from "@/lib/schema";
+import type { UserInfoUpdateData } from "@/types/user";
+
+/**
+ * Service layer for user-related business logic
+ *
+ * This layer contains pure business logic without framework dependencies,
+ * making it easy to test and reuse in different contexts.
+ */
+
+/**
+ * Result type for service operations
+ */
+export interface ServiceResult<T = void> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+}
+
+/**
+ * Update user profile information
+ *
+ * This function contains the core business logic for updating user info.
+ * It performs the following:
+ * 1. Builds update object dynamically (only includes provided fields)
+ * 2. Handles empty strings by converting to null (except for required fields)
+ * 3. Updates the database
+ *
+ * @param userId - The ID of the user to update
+ * @param data - Validated user info data (all fields optional)
+ * @returns Result object with success status and message/error
+ */
+export async function updateUserInfo(
+  userId: string,
+  data: UserInfoUpdateData
+): Promise<ServiceResult> {
+  try {
+    const { nickname, name, gender, birthday } = data;
+
+    // Build update object dynamically (only include provided fields)
+    const updateData: {
+      nickname?: string | null;
+      name?: string;
+      gender?: "male" | "female" | "other" | null;
+      birthday?: string | null;
+      updatedAt: Date;
+    } = {
+      updatedAt: new Date(),
+    };
+
+    // Only add fields that are provided (not undefined)
+    if (nickname !== undefined) {
+      updateData.nickname = nickname === "" ? null : nickname;
+    }
+    // name is required in DB, so only update if a non-empty value is provided
+    if (name !== undefined && name !== "") {
+      updateData.name = name;
+    }
+    if (gender !== undefined) {
+      updateData.gender = gender;
+    }
+    if (birthday !== undefined) {
+      updateData.birthday = birthday === "" ? null : birthday;
+    }
+
+    // Update database
+    await db.update(user).set(updateData).where(eq(user.id, userId));
+
+    return {
+      success: true,
+      message: "User information updated successfully",
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Failed to update user information",
+    };
+  }
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+/**
+ * User info update schema
+ * All fields are optional - users can update only specific fields
+ */
+export const userInfoUpdateSchema = z.object({
+  nickname: z
+    .union([
+      z.string().max(50, "Nickname cannot exceed 50 characters"),
+      z.literal(""),
+    ])
+    .optional(),
+
+  name: z
+    .union([
+      z.string().max(50, "Name cannot exceed 50 characters"),
+      z.literal(""),
+    ])
+    .optional(),
+
+  gender: z
+    .enum(["male", "female", "other"], {
+      message: "Gender must be male, female, or other",
+    })
+    .optional(),
+
+  birthday: z
+    .union([
+      z
+        .string()
+        .regex(/^\d{4}-\d{2}-\d{2}$/, "Birthday must be in yyyy-mm-dd format"),
+      z.literal(""),
+    ])
+    .optional(),
+});
+
+export type UserInfoUpdateData = z.infer<typeof userInfoUpdateSchema>;


### PR DESCRIPTION
## 描述

引入了一个全新的用户个人信息管理功能，允许用户通过一个专用的页面查看和修改其个人资料，如昵称、姓名、性别和生日等，并查看邮箱和手机号的绑定验证信息。

## 相关问题

Resolve #128 

## 变更类型

- [ ] Bug 修复（不会破坏现有功能的非破坏性变更）
- [x] 新功能（添加功能的非破坏性变更）
- [ ] 破坏性变更（会导致现有功能无法正常工作的修复或功能）
- [ ] 文档更新
- [ ] 性能改进
- [ ] 代码重构
- [ ] CI/CD 改进

## 测试

- [x] 我已经在本地测试了这些更改
- [x] 我已经添加了证明我的修复有效或我的功能工作的测试
- [x] 新的和现有的单元测试在我的更改下都能通过
- [x] 我已经检查了代码能够无错误地构建

## 截图（如果适用）

<img width="2940" height="1506" alt="image" src="https://github.com/user-attachments/assets/11f646aa-1846-43a0-829a-637720d3dd43" />

## 检查清单

- [x] 我的代码遵循此项目的代码风格
- [x] 我已经对自己的代码进行了自我审查
- [x] 我已经对代码进行了注释，特别是在难以理解的地方
- [x] 我已经对文档进行了相应的更改
- [x] 我的更改没有产生新的警告
- [x] 我已经添加了证明我的修复有效或我的功能工作的测试
- [x] 新的和现有的单元测试在我的更改下都能通过

## 代码审查检查清单（供审查者使用）

- [ ] 代码可读且有良好的文档
- [ ] 更改经过了适当的测试
- [ ] 没有明显的性能问题
- [ ] 已解决安全考虑
- [ ] 破坏性变更已得到适当记录

## 附加说明

未实现邮箱/手机号验证/修改功能，应该在 #131 中一起实现
