### PR TITLE
feat: add global navigation sidebar

### DIFF
--- a/src/app/(frontend)/flights/page.client.tsx
+++ b/src/app/(frontend)/flights/page.client.tsx
@@ -27,7 +27,7 @@ export function FlightsPageClient({
   const router = useRouter();
   const searchParams = useSearchParams();
   const tabParam = searchParams.get("tab");
-  const defaultTab = tabParam || "domestic";
+  const currentTab = tabParam || "domestic";
 
   const handleSearch = (data: SearchFormData) => {
     // Build search parameters
@@ -51,11 +51,25 @@ export function FlightsPageClient({
     router.push(`/flights/search?${params.toString()}`);
   };
 
+  const handleTabChange = (value: string) => {
+    // Update URL with new tab parameter
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === "domestic") {
+      params.delete("tab");
+    } else {
+      params.set("tab", value);
+    }
+    const newUrl = params.toString()
+      ? `/flights?${params.toString()}`
+      : "/flights";
+    router.push(newUrl);
+  };
+
   return (
     <div className="container mx-auto px-4 py-8 max-w-8xl">
       {/* Search Form Card */}
 
-      <Tabs defaultValue={defaultTab}>
+      <Tabs value={currentTab} onValueChange={handleTabChange}>
         <TabsList className="w-full h-12 grid grid-cols-6">
           <TabsTrigger value="domestic">国内、国际/中国港澳台</TabsTrigger>
           <TabsTrigger value="special">特价机票</TabsTrigger>

--- a/src/app/(frontend)/flights/page.client.tsx
+++ b/src/app/(frontend)/flights/page.client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Trash2 } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import { UnderConstruction } from "@/components/common";
 import {
@@ -25,6 +25,9 @@ export function FlightsPageClient({
   searchHistory,
 }: FlightsPageClientProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const tabParam = searchParams.get("tab");
+  const defaultTab = tabParam || "domestic";
 
   const handleSearch = (data: SearchFormData) => {
     // Build search parameters
@@ -52,7 +55,7 @@ export function FlightsPageClient({
     <div className="container mx-auto px-4 py-8 max-w-8xl">
       {/* Search Form Card */}
 
-      <Tabs defaultValue="domestic">
+      <Tabs defaultValue={defaultTab}>
         <TabsList className="w-full h-12 grid grid-cols-6">
           <TabsTrigger value="domestic">国内、国际/中国港澳台</TabsTrigger>
           <TabsTrigger value="special">特价机票</TabsTrigger>

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -2,14 +2,20 @@ import "./globals.css";
 
 import type { ReactNode } from "react";
 
-import { Footer, Header } from "@/components/common";
+import { Footer, Header, MainSidebar } from "@/components/common";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 
 export default function FrontendLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="flex min-h-screen flex-col">
-      <Header />
-      <main className="flex-1">{children}</main>
-      <Footer />
-    </div>
+    <SidebarProvider defaultOpen={true}>
+      <MainSidebar />
+      <SidebarInset>
+        <div className="flex min-h-screen flex-col">
+          <Header />
+          <main className="flex-1">{children}</main>
+          <Footer />
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
   );
 }

--- a/src/components/common/app-sidebar.tsx
+++ b/src/components/common/app-sidebar.tsx
@@ -20,10 +20,11 @@ import {
   Ticket,
   Train,
 } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import * as React from "react";
 import { toast } from "sonner";
 
+import { Button } from "@/components/ui/button";
 import {
   HoverCard,
   HoverCardContent,
@@ -42,6 +43,7 @@ import {
   SidebarRail,
   useSidebar,
 } from "@/components/ui/sidebar";
+import { cn } from "@/lib/utils";
 
 // Type definitions
 type SubItem = {
@@ -197,8 +199,16 @@ export const data: SidebarData = {
 // Menu item component with hover card for sub-items
 function SidebarMenuItemWithHover({ item }: { item: MenuItem }) {
   const router = useRouter();
+  const pathname = usePathname();
   const Icon = item.icon;
   const hasSubItems = item.items && item.items.length > 0;
+
+  // Check if current item or any of its sub-items is active
+  const isMainActive = pathname === item.url;
+  const activeSubItem = hasSubItems
+    ? item.items?.find(subItem => pathname === subItem.url)
+    : null;
+  const isExpanded = isMainActive || !!activeSubItem;
 
   const handleClick = (url: string, title: string) => {
     if (url === "#") {
@@ -213,7 +223,11 @@ function SidebarMenuItemWithHover({ item }: { item: MenuItem }) {
   const menuButton = (
     <SidebarMenuButton
       onClick={() => handleClick(item.url, item.title)}
-      className="h-9 cursor-pointer px-2"
+      className={cn(
+        "h-9 cursor-pointer px-2",
+        isExpanded &&
+          "bg-blue-500 text-white hover:bg-blue-600 hover:text-white rounded-full"
+      )}
     >
       <Icon className="size-4" />
       <span className="text-sm">{item.title}</span>
@@ -225,7 +239,36 @@ function SidebarMenuItemWithHover({ item }: { item: MenuItem }) {
     return <SidebarMenuItem>{menuButton}</SidebarMenuItem>;
   }
 
-  // If has sub-items, wrap with HoverCard
+  // If has sub-items and is expanded, show sub-items below
+  if (isExpanded) {
+    return (
+      <div className="space-y-0">
+        <SidebarMenuItem>{menuButton}</SidebarMenuItem>
+        <div className="ml-2 space-y-0">
+          {item.items?.map((subItem, index) => {
+            const isSubActive = pathname === subItem.url;
+            return (
+              <Button
+                key={index}
+                variant="ghost"
+                onClick={() => handleClick(subItem.url, subItem.title)}
+                className={cn(
+                  "w-full text-left px-3 py-2 text-sm rounded-md transition-colors",
+                  isSubActive
+                    ? "text-blue-500 font-medium"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {subItem.title}
+              </Button>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  // If has sub-items but not expanded, wrap with HoverCard
   return (
     <SidebarMenuItem>
       <HoverCard openDelay={100} closeDelay={100}>

--- a/src/components/common/app-sidebar.tsx
+++ b/src/components/common/app-sidebar.tsx
@@ -201,11 +201,15 @@ function SidebarMenuItemWithHover({ item }: { item: MenuItem }) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const { state: sidebarState } = useSidebar();
   const Icon = item.icon;
   const hasSubItems = item.items && item.items.length > 0;
 
   // Helper function to check if a URL matches the current location
   const isUrlActive = (url: string) => {
+    // Don't match "#" URLs
+    if (url === "#") return false;
+
     try {
       const urlObj = new URL(url, window.location.origin);
       const urlPath = urlObj.pathname;
@@ -234,7 +238,10 @@ function SidebarMenuItemWithHover({ item }: { item: MenuItem }) {
   const activeSubItem = hasSubItems
     ? item.items?.find(subItem => isUrlActive(subItem.url))
     : null;
-  const isExpanded = isMainActive || !!activeSubItem;
+  const isActive = isMainActive || !!activeSubItem;
+
+  // Only expand sub-items if active AND sidebar is expanded
+  const shouldExpandSubItems = isActive && sidebarState === "expanded";
 
   const handleClick = (url: string, title: string) => {
     if (url === "#") {
@@ -251,7 +258,7 @@ function SidebarMenuItemWithHover({ item }: { item: MenuItem }) {
       onClick={() => handleClick(item.url, item.title)}
       className={cn(
         "h-9 cursor-pointer px-2",
-        isExpanded &&
+        isActive &&
           "bg-blue-500 text-white hover:bg-blue-600 hover:text-white rounded-full"
       )}
     >
@@ -265,8 +272,8 @@ function SidebarMenuItemWithHover({ item }: { item: MenuItem }) {
     return <SidebarMenuItem>{menuButton}</SidebarMenuItem>;
   }
 
-  // If has sub-items and is expanded, show sub-items below
-  if (isExpanded) {
+  // If has sub-items and should expand, show sub-items below
+  if (shouldExpandSubItems) {
     return (
       <div className="space-y-0">
         <SidebarMenuItem>{menuButton}</SidebarMenuItem>

--- a/src/components/common/app-sidebar.tsx
+++ b/src/components/common/app-sidebar.tsx
@@ -213,11 +213,10 @@ function SidebarMenuItemWithHover({ item }: { item: MenuItem }) {
   const menuButton = (
     <SidebarMenuButton
       onClick={() => handleClick(item.url, item.title)}
-      className="h-11 cursor-pointer"
-      tooltip={item.title}
+      className="h-9 cursor-pointer px-2"
     >
-      <Icon className="size-5" />
-      <span>{item.title}</span>
+      <Icon className="size-4" />
+      <span className="text-sm">{item.title}</span>
     </SidebarMenuButton>
   );
 
@@ -265,7 +264,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           <SidebarMenuItem>
             <SidebarMenuButton
               aria-label="Toggle Sidebar"
-              className="size-11 p-3.5 justify-center rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-900 [&>svg]:size-7"
+              className="px-3 py-3 size-8 justify-center rounded-md [&>svg]:size-7"
               onClick={() => toggleSidebar()}
             >
               <Menu strokeWidth={1.5} className="text-black" />

--- a/src/components/common/app-sidebar.tsx
+++ b/src/components/common/app-sidebar.tsx
@@ -229,7 +229,7 @@ function SidebarMenuItemWithHover({ item }: { item: MenuItem }) {
   // If has sub-items, wrap with HoverCard
   return (
     <SidebarMenuItem>
-      <HoverCard openDelay={200} closeDelay={100}>
+      <HoverCard openDelay={100} closeDelay={100}>
         <HoverCardTrigger asChild>{menuButton}</HoverCardTrigger>
         <HoverCardContent
           side="right"
@@ -258,8 +258,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const { toggleSidebar } = useSidebar();
 
   return (
-    <Sidebar collapsible="icon" {...props}>
-      <SidebarHeader className="gap-2 p-2">
+    <Sidebar collapsible="icon" className="w-48" {...props}>
+      <SidebarHeader className="gap-2 p-2 flex items-center justify-center">
         {/* Toggle sidebar button */}
         <SidebarMenu>
           <SidebarMenuItem>
@@ -274,7 +274,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         </SidebarMenu>
       </SidebarHeader>
 
-      <SidebarContent>
+      <SidebarContent className="px-2">
         {/* Travel Group */}
         <SidebarGroup>
           <SidebarGroupContent>
@@ -286,7 +286,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           </SidebarGroupContent>
         </SidebarGroup>
 
-        <Separator />
+        <Separator className="mx-2" />
 
         {/* Business Group */}
         <SidebarGroup>
@@ -299,7 +299,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           </SidebarGroupContent>
         </SidebarGroup>
 
-        <Separator />
+        <Separator className="mx-2" />
 
         {/* Finance Group */}
         <SidebarGroup>
@@ -312,7 +312,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           </SidebarGroupContent>
         </SidebarGroup>
 
-        <Separator />
+        <Separator className="mx-2" />
 
         {/* Extras Group */}
         <SidebarGroup>

--- a/src/components/common/app-sidebar.tsx
+++ b/src/components/common/app-sidebar.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import {
+  Bed,
+  Building2,
+  Bus,
+  Car,
+  Compass,
+  CreditCard,
+  Frame,
+  Gift,
+  Globe,
+  Info,
+  LucideIcon,
+  Map,
+  Menu,
+  Plane,
+  ShoppingCart,
+  Sparkles,
+  Ticket,
+  Train,
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+import * as React from "react";
+import { toast } from "sonner";
+
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { Separator } from "@/components/ui/separator";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarRail,
+  useSidebar,
+} from "@/components/ui/sidebar";
+
+// Type definitions
+type SubItem = {
+  title: string;
+  url: string;
+};
+
+type MenuItem = {
+  title: string;
+  url: string;
+  icon: LucideIcon;
+  items?: SubItem[];
+};
+
+type SidebarData = {
+  travel: MenuItem[];
+  business: MenuItem[];
+  finance: MenuItem[];
+  extras: MenuItem[];
+};
+
+// Sidebar data structure
+export const data: SidebarData = {
+  // Travel group - 旅行相关
+  travel: [
+    {
+      title: "酒店",
+      url: "#",
+      icon: Bed,
+      items: [
+        { title: "国内酒店", url: "#" },
+        { title: "海外酒店", url: "#" },
+      ],
+    },
+    {
+      title: "机票",
+      url: "/flights",
+      icon: Plane,
+      items: [
+        { title: "国内/国际/中国港澳台", url: "/flights?tab=domestic" },
+        { title: "特价机票", url: "/flights?tab=special" },
+        { title: "航班动态", url: "/flights?tab=status" },
+        { title: "在线选座", url: "/flights?tab=seat" },
+        { title: "退票改签", url: "/flights?tab=refund" },
+        { title: "更多服务", url: "/flights?tab=more" },
+      ],
+    },
+    {
+      title: "火车票",
+      url: "#",
+      icon: Train,
+      items: [
+        { title: "国内火车票", url: "#" },
+        { title: "国际/中国港澳台", url: "#" },
+      ],
+    },
+    {
+      title: "旅游",
+      url: "#",
+      icon: Globe,
+      items: [
+        { title: "国内游", url: "#" },
+        { title: "出境游", url: "#" },
+        { title: "自由行", url: "#" },
+      ],
+    },
+    {
+      title: "门票·活动",
+      url: "#",
+      icon: Ticket,
+      items: [
+        { title: "景点门票", url: "#" },
+        { title: "演出活动", url: "#" },
+      ],
+    },
+    {
+      title: "汽车·船票",
+      url: "#",
+      icon: Bus,
+      items: [
+        { title: "汽车票", url: "#" },
+        { title: "船票", url: "#" },
+      ],
+    },
+    {
+      title: "用车",
+      url: "#",
+      icon: Car,
+      items: [
+        { title: "国内租车", url: "#" },
+        { title: "境外租车", url: "#" },
+        { title: "接送机站", url: "#" },
+        { title: "拼车", url: "#" },
+      ],
+    },
+  ],
+  // Business group - 商务相关
+  business: [
+    {
+      title: "企业商旅",
+      url: "#",
+      icon: Building2,
+    },
+    {
+      title: "老友会",
+      url: "#",
+      icon: Frame,
+    },
+    {
+      title: "关于携程",
+      url: "#",
+      icon: Info,
+    },
+  ],
+  // Finance group - 金融相关
+  finance: [
+    {
+      title: "全球购",
+      url: "#",
+      icon: ShoppingCart,
+    },
+    {
+      title: "礼品卡",
+      url: "#",
+      icon: Gift,
+    },
+    {
+      title: "携程金融",
+      url: "#",
+      icon: CreditCard,
+    },
+  ],
+  // Extras group - 额外功能
+  extras: [
+    {
+      title: "AI行程助手",
+      url: "#",
+      icon: Sparkles,
+    },
+    {
+      title: "攻略·景点",
+      url: "#",
+      icon: Compass,
+    },
+    {
+      title: "旅游地图",
+      url: "#",
+      icon: Map,
+    },
+  ],
+};
+
+// Menu item component with hover card for sub-items
+function SidebarMenuItemWithHover({ item }: { item: MenuItem }) {
+  const router = useRouter();
+  const Icon = item.icon;
+  const hasSubItems = item.items && item.items.length > 0;
+
+  const handleClick = (url: string, title: string) => {
+    if (url === "#") {
+      toast.info(`"${title}" 功能暂未实现`, {
+        description: "该功能正在开发中，敬请期待",
+      });
+    } else {
+      router.push(url);
+    }
+  };
+
+  const menuButton = (
+    <SidebarMenuButton
+      onClick={() => handleClick(item.url, item.title)}
+      className="h-11 cursor-pointer"
+      tooltip={item.title}
+    >
+      <Icon className="size-5" />
+      <span>{item.title}</span>
+    </SidebarMenuButton>
+  );
+
+  // If no sub-items, just return the button
+  if (!hasSubItems) {
+    return <SidebarMenuItem>{menuButton}</SidebarMenuItem>;
+  }
+
+  // If has sub-items, wrap with HoverCard
+  return (
+    <SidebarMenuItem>
+      <HoverCard openDelay={200} closeDelay={100}>
+        <HoverCardTrigger asChild>{menuButton}</HoverCardTrigger>
+        <HoverCardContent
+          side="right"
+          align="start"
+          className="w-56 p-2"
+          sideOffset={8}
+        >
+          <div className="space-y-1">
+            {item.items?.map((subItem, index) => (
+              <button
+                key={index}
+                onClick={() => handleClick(subItem.url, subItem.title)}
+                className="w-full text-left px-3 py-2 text-sm rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
+              >
+                {subItem.title}
+              </button>
+            ))}
+          </div>
+        </HoverCardContent>
+      </HoverCard>
+    </SidebarMenuItem>
+  );
+}
+
+export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <Sidebar collapsible="icon" {...props}>
+      <SidebarHeader className="gap-2 p-2">
+        {/* Toggle sidebar button */}
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              aria-label="Toggle Sidebar"
+              className="size-11 p-3.5 justify-center rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-900 [&>svg]:size-7"
+              onClick={() => toggleSidebar()}
+            >
+              <Menu strokeWidth={1.5} className="text-black" />
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+
+      <SidebarContent>
+        {/* Travel Group */}
+        <SidebarGroup>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {data.travel.map((item, index) => (
+                <SidebarMenuItemWithHover key={index} item={item} />
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        <Separator />
+
+        {/* Business Group */}
+        <SidebarGroup>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {data.business.map((item, index) => (
+                <SidebarMenuItemWithHover key={index} item={item} />
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        <Separator />
+
+        {/* Finance Group */}
+        <SidebarGroup>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {data.finance.map((item, index) => (
+                <SidebarMenuItemWithHover key={index} item={item} />
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        <Separator />
+
+        {/* Extras Group */}
+        <SidebarGroup>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {data.extras.map((item, index) => (
+                <SidebarMenuItemWithHover key={index} item={item} />
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+
+      <SidebarRail />
+    </Sidebar>
+  );
+}

--- a/src/components/common/app-sidebar.tsx
+++ b/src/components/common/app-sidebar.tsx
@@ -21,7 +21,7 @@ import {
   Train,
 } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import * as React from "react";
+import { useCallback } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -206,32 +206,44 @@ function SidebarMenuItemWithHover({ item }: { item: MenuItem }) {
   const hasSubItems = item.items && item.items.length > 0;
 
   // Helper function to check if a URL matches the current location
-  const isUrlActive = (url: string) => {
-    // Don't match "#" URLs
-    if (url === "#") return false;
+  const isUrlActive = useCallback(
+    (url: string) => {
+      // Don't match "#" URLs
+      if (url === "#") return false;
 
-    try {
-      const urlObj = new URL(url, window.location.origin);
-      const urlPath = urlObj.pathname;
-      const urlParams = urlObj.searchParams;
+      try {
+        const urlObj = new URL(url, window.location.origin);
+        const urlPath = urlObj.pathname;
+        const urlParams = urlObj.searchParams;
 
-      // Check if pathname matches
-      if (pathname !== urlPath) return false;
+        // Check if pathname matches
+        if (pathname !== urlPath) return false;
 
-      // If URL has no query params, just check pathname
-      if (urlParams.toString() === "") return true;
+        // If URL has no query params, just check pathname
+        if (urlParams.toString() === "") return true;
 
-      // Check if all URL params match current search params
-      for (const [key, value] of urlParams.entries()) {
-        if (searchParams.get(key) !== value) return false;
+        // Handle default tab for flights page
+        if (
+          urlPath === "/flights" &&
+          urlParams.get("tab") === "domestic" &&
+          !searchParams.has("tab")
+        ) {
+          return true;
+        }
+
+        // Check if all URL params match current search params
+        for (const [key, value] of urlParams.entries()) {
+          if (searchParams.get(key) !== value) return false;
+        }
+
+        return true;
+      } catch {
+        // If URL parsing fails, fall back to simple pathname comparison
+        return pathname === url;
       }
-
-      return true;
-    } catch {
-      // If URL parsing fails, fall back to simple pathname comparison
-      return pathname === url;
-    }
-  };
+    },
+    [pathname, searchParams]
+  );
 
   // Check if current item or any of its sub-items is active
   const isMainActive = isUrlActive(item.url);
@@ -278,11 +290,11 @@ function SidebarMenuItemWithHover({ item }: { item: MenuItem }) {
       <div className="space-y-0">
         <SidebarMenuItem>{menuButton}</SidebarMenuItem>
         <div className="ml-2 space-y-0">
-          {item.items?.map((subItem, index) => {
+          {item.items?.map(subItem => {
             const isSubActive = isUrlActive(subItem.url);
             return (
               <Button
-                key={index}
+                key={subItem.title}
                 variant="ghost"
                 onClick={() => handleClick(subItem.url, subItem.title)}
                 className={cn(
@@ -313,9 +325,9 @@ function SidebarMenuItemWithHover({ item }: { item: MenuItem }) {
           sideOffset={8}
         >
           <div className="space-y-1">
-            {item.items?.map((subItem, index) => (
+            {item.items?.map(subItem => (
               <button
-                key={index}
+                key={subItem.title}
                 onClick={() => handleClick(subItem.url, subItem.title)}
                 className="w-full text-left px-3 py-2 text-sm rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
               >
@@ -354,8 +366,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
-              {data.travel.map((item, index) => (
-                <SidebarMenuItemWithHover key={index} item={item} />
+              {data.travel.map(item => (
+                <SidebarMenuItemWithHover key={item.title} item={item} />
               ))}
             </SidebarMenu>
           </SidebarGroupContent>
@@ -367,8 +379,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
-              {data.business.map((item, index) => (
-                <SidebarMenuItemWithHover key={index} item={item} />
+              {data.business.map(item => (
+                <SidebarMenuItemWithHover key={item.title} item={item} />
               ))}
             </SidebarMenu>
           </SidebarGroupContent>
@@ -380,8 +392,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
-              {data.finance.map((item, index) => (
-                <SidebarMenuItemWithHover key={index} item={item} />
+              {data.finance.map(item => (
+                <SidebarMenuItemWithHover key={item.title} item={item} />
               ))}
             </SidebarMenu>
           </SidebarGroupContent>
@@ -393,8 +405,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
-              {data.extras.map((item, index) => (
-                <SidebarMenuItemWithHover key={index} item={item} />
+              {data.extras.map(item => (
+                <SidebarMenuItemWithHover key={item.title} item={item} />
               ))}
             </SidebarMenu>
           </SidebarGroupContent>

--- a/src/components/common/app-sidebar.tsx
+++ b/src/components/common/app-sidebar.tsx
@@ -20,7 +20,7 @@ import {
   Ticket,
   Train,
 } from "lucide-react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import * as React from "react";
 import { toast } from "sonner";
 
@@ -200,13 +200,39 @@ export const data: SidebarData = {
 function SidebarMenuItemWithHover({ item }: { item: MenuItem }) {
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const Icon = item.icon;
   const hasSubItems = item.items && item.items.length > 0;
 
+  // Helper function to check if a URL matches the current location
+  const isUrlActive = (url: string) => {
+    try {
+      const urlObj = new URL(url, window.location.origin);
+      const urlPath = urlObj.pathname;
+      const urlParams = urlObj.searchParams;
+
+      // Check if pathname matches
+      if (pathname !== urlPath) return false;
+
+      // If URL has no query params, just check pathname
+      if (urlParams.toString() === "") return true;
+
+      // Check if all URL params match current search params
+      for (const [key, value] of urlParams.entries()) {
+        if (searchParams.get(key) !== value) return false;
+      }
+
+      return true;
+    } catch {
+      // If URL parsing fails, fall back to simple pathname comparison
+      return pathname === url;
+    }
+  };
+
   // Check if current item or any of its sub-items is active
-  const isMainActive = pathname === item.url;
+  const isMainActive = isUrlActive(item.url);
   const activeSubItem = hasSubItems
-    ? item.items?.find(subItem => pathname === subItem.url)
+    ? item.items?.find(subItem => isUrlActive(subItem.url))
     : null;
   const isExpanded = isMainActive || !!activeSubItem;
 
@@ -246,7 +272,7 @@ function SidebarMenuItemWithHover({ item }: { item: MenuItem }) {
         <SidebarMenuItem>{menuButton}</SidebarMenuItem>
         <div className="ml-2 space-y-0">
           {item.items?.map((subItem, index) => {
-            const isSubActive = pathname === subItem.url;
+            const isSubActive = isUrlActive(subItem.url);
             return (
               <Button
                 key={index}

--- a/src/components/common/index.tsx
+++ b/src/components/common/index.tsx
@@ -1,6 +1,7 @@
 import { Stepper, type StepperStep } from "@/components/common/stepper";
 
 export { Stepper, type StepperStep };
+export { AppSidebar as MainSidebar } from "./app-sidebar";
 export { default as UnderConstruction } from "./construction";
 export {
   type BatchAction,


### PR DESCRIPTION
## 描述

实现了全局应用侧边栏（AppSidebar）的完整功能，包括分组导航、子菜单展开、路径高亮等核心交互特性。

### 主要功能
- **分组导航结构**：将导航项分为旅行、商务、金融、额外功能四个组，组间使用水平分割线
- **主元素与子元素**：支持主元素包含可选的子元素列表（如机票包含国内/国际、特价机票等子项）
- **智能子菜单显示**：
  - 未选中状态：鼠标悬停时在右侧以 HoverCard 形式显示子元素
  - 选中状态：子元素自动在主元素下方展开显示
- **路径高亮**：
  - 根据当前 pathname 和 URL 参数自动高亮对应的主元素和子元素
  - 主元素选中时显示蓝色圆角背景
  - 子元素选中时显示蓝色文字
- **URL 参数支持**：正确匹配带查询参数的 URL（如 `/flights?tab=special`）
- **智能跳转**：
  - 已实现功能：直接跳转到对应页面
  - 未实现功能（url: #）：弹出 Sonner toast 提示
- **全局布局集成**：侧边栏已集成到 `(frontend)` 布局中，与 Header/Footer 协同工作

### 配套调整
- 修改 `/flights` 页面，使 Tabs 组件响应 URL 的 `tab` 参数变化
- 实现受控 Tabs 组件，支持通过 sidebar 子元素点击切换 tab

## 相关问题

Resolves #125 

## 变更类型

- [ ] Bug 修复（不会破坏现有功能的非破坏性变更）
- [x] 新功能（添加功能的非破坏性变更）
- [ ] 破坏性变更（会导致现有功能无法正常工作的修复或功能）
- [ ] 文档更新
- [ ] 性能改进
- [ ] 代码重构
- [ ] CI/CD 改进

## 测试

- [x] 我已经在本地测试了这些更改
- [x] 我已经添加了证明我的修复有效或我的功能工作的测试
- [x] 新的和现有的单元测试在我的更改下都能通过
- [x] 我已经检查了代码能够无错误地构建

## 截图（如果适用）

<img width="404" height="348" alt="image" src="https://github.com/user-attachments/assets/45516f5d-d4c2-4f01-a14d-bf5247be0481" />

## 检查清单

- [x] 我的代码遵循此项目的代码风格
- [x] 我已经对自己的代码进行了自我审查
- [x] 我已经对代码进行了注释，特别是在难以理解的地方
- [x] 我已经对文档进行了相应的更改
- [x] 我的更改没有产生新的警告
- [x] 我已经添加了证明我的修复有效或我的功能工作的测试
- [x] 新的和现有的单元测试在我的更改下都能通过

## 代码审查检查清单（供审查者使用）

- [ ] 代码可读且有良好的文档
- [ ] 更改经过了适当的测试
- [ ] 没有明显的性能问题
- [ ] 已解决安全考虑
- [ ] 破坏性变更已得到适当记录

## 附加说明

- 当前 sidebar 会在所有 `(frontend)` 路由下显示，包括 `/home`（该路由有自己的 UserSidebar），参考 #156 