### PR TITLE
fix (date-selector): resolve date selection issues

### DIFF
--- a/app/_components/flights/search/date-selector/date-selector.test.tsx
+++ b/app/_components/flights/search/date-selector/date-selector.test.tsx
@@ -1,14 +1,29 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { addDays } from "date-fns";
+import { addDays, format } from "date-fns";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DateDisplay } from "./date-display";
 import { DateSelector } from "./date-selector";
 
-describe("DateSelector", () => {
-  const today = new Date("2025-11-15");
+const getTestDates = () => {
+  const today = new Date();
   today.setHours(0, 0, 0, 0);
+
+  return {
+    today,
+    fiveDaysLater: addDays(today, 5),
+    sixDaysLater: addDays(today, 6),
+    sevenDaysLater: addDays(today, 7),
+    tenDaysLater: addDays(today, 10),
+    elevenDaysLater: addDays(today, 11),
+    twelveDaysLater: addDays(today, 12),
+    thirteenDaysLater: addDays(today, 13),
+  };
+};
+
+describe("DateSelector", () => {
+  const baseDates = getTestDates();
 
   const defaultProps = {
     tripType: "one-way" as const,
@@ -16,7 +31,7 @@ describe("DateSelector", () => {
     returnDate: null,
     onDepartureDateChange: vi.fn(),
     onReturnDateChange: vi.fn(),
-    minDate: today,
+    minDate: baseDates.today,
   };
 
   beforeEach(() => {
@@ -113,6 +128,373 @@ describe("DateSelector", () => {
       );
 
       expect(screen.queryByText("1天")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("User interaction scenarios - Date field selection", () => {
+    /**
+     * Helper function to click a date button in the calendar
+     * Uses relative day number to work regardless of when tests are run
+     */
+    const clickDateButton = async (
+      user: ReturnType<typeof userEvent.setup>,
+      targetDate: Date
+    ) => {
+      const targetDay = format(targetDate, "d");
+      const dateButtons = screen.getAllByRole("button");
+      const targetButton = dateButtons.find(
+        btn =>
+          btn.textContent === targetDay && !(btn as HTMLButtonElement).disabled
+      );
+      if (!targetButton) {
+        throw new Error(`Could not find date button for day ${targetDay}`);
+      }
+      await user.click(targetButton);
+    };
+
+    /**
+     * Test Results Summary (Before Fix):
+     * ====================================
+     *
+     * Scenario 1 (First click departure): FAILED
+     *   - Expected: Update departure to selected date
+     *   - Actual: Updated departure to original value
+     *   - Issue: onClick handler not triggered, date not updated correctly
+     *
+     * Scenario 2 (First click return): FAILED
+     *   - Expected: Update return to selected date
+     *   - Actual: Updated return to wrong date/time
+     *   - Issue: Timezone or date calculation issue
+     *
+     * Scenario 3 (Switch from return to departure): FAILED
+     *   - Expected: Update departure to selected date
+     *   - Actual: Updated departure to original value
+     *   - Issue: activeField not updated when clicking departure after return
+     *
+     * Scenario 4 (Switch from departure to return): FAILED
+     *   - Expected: Update return to selected date
+     *   - Actual: Updated return to wrong date/time
+     *   - Issue: activeField not updated correctly
+     *
+     * Scenario 5 (Multiple departure modifications): FAILED
+     *   - Expected: Each update uses the newly selected date
+     *   - Actual: Both updates returned original value
+     *   - Issue: Persistent activeField issue
+     *
+     * Scenario 6 (Multiple return modifications): FAILED
+     *   - Expected: Each update uses the newly selected date
+     *   - Actual: Both updates returned wrong dates
+     *   - Issue: Persistent activeField issue
+     *
+     * Scenario 7 (Alternating clicks): FAILED
+     *   - Expected: Correctly alternate between departure and return updates
+     *   - Actual: All updates returned wrong dates
+     *   - Issue: activeField never updates correctly on user clicks
+     *
+     * Root Cause:
+     * -----------
+     * The DropdownMenuTrigger component with asChild prop prevents the onClick
+     * handlers (onDepartureClick, onReturnClick) from being triggered. This means
+     * activeField is never updated, causing all date selections to update the
+     * wrong field or use stale date values.
+     *
+     * Note on Test Design:
+     * --------------------
+     * These tests use relative dates (e.g., "5 days from now") instead of
+     * hardcoded dates (e.g., "2025-11-20"). This ensures tests remain valid
+     * regardless of when they are run. For example, a test run on 2025-12-01
+     * can still select dates in the future, whereas hardcoded November dates
+     * would fail as they would be in the past.
+     */
+
+    // Scenario 1: First time user clicks departure date
+    it("should update departure date when user clicks departure field for the first time", async () => {
+      const user = userEvent.setup();
+      const dates = getTestDates();
+
+      // Setup: departure is 5 days from now, return is 10 days from now
+      const initialDeparture = dates.fiveDaysLater;
+      const initialReturn = dates.tenDaysLater;
+      const onDepartureDateChange = vi.fn();
+      const onReturnDateChange = vi.fn();
+
+      render(
+        <DateSelector
+          {...defaultProps}
+          tripType="round-trip"
+          departureDate={initialDeparture}
+          returnDate={initialReturn}
+          onDepartureDateChange={onDepartureDateChange}
+          onReturnDateChange={onReturnDateChange}
+          minDate={dates.today}
+        />
+      );
+
+      // User clicks departure date field
+      const departureDateField = screen.getByText("出发日期").closest("div");
+      await user.click(departureDateField!);
+
+      // User selects a new date (7 days from now)
+      const targetDate = dates.sevenDaysLater;
+      await clickDateButton(user, targetDate);
+
+      // Expected: departure date should be updated to selected date
+      expect(onDepartureDateChange).toHaveBeenCalledWith(targetDate);
+      // Return date should not change
+      expect(onReturnDateChange).not.toHaveBeenCalled();
+    });
+
+    // Scenario 2: First time user clicks return date
+    it("should update return date when user clicks return field for the first time", async () => {
+      const dates = getTestDates();
+      const user = userEvent.setup();
+      const initialDeparture = dates.fiveDaysLater;
+      const initialReturn = dates.tenDaysLater;
+      const onDepartureDateChange = vi.fn();
+      const onReturnDateChange = vi.fn();
+
+      render(
+        <DateSelector
+          {...defaultProps}
+          tripType="round-trip"
+          departureDate={initialDeparture}
+          returnDate={initialReturn}
+          onDepartureDateChange={onDepartureDateChange}
+          onReturnDateChange={onReturnDateChange}
+        />
+      );
+
+      // User clicks return date field
+      const returnDateField = screen.getByText("返回日期").closest("div");
+      await user.click(returnDateField!);
+
+      // User selects a new date
+      await clickDateButton(user, dates.twelveDaysLater);
+
+      // Expected: return date should be updated
+      expect(onReturnDateChange).toHaveBeenCalledWith(dates.twelveDaysLater);
+      // Departure date should not change
+      expect(onDepartureDateChange).not.toHaveBeenCalled();
+    });
+
+    // Scenario 3: User switches from return to departure
+    it("should update departure when user switches from return field to departure field", async () => {
+      const dates = getTestDates();
+      const user = userEvent.setup();
+      const initialDeparture = dates.fiveDaysLater;
+      const initialReturn = dates.tenDaysLater;
+      const onDepartureDateChange = vi.fn();
+      const onReturnDateChange = vi.fn();
+
+      render(
+        <DateSelector
+          {...defaultProps}
+          tripType="round-trip"
+          departureDate={initialDeparture}
+          returnDate={initialReturn}
+          onDepartureDateChange={onDepartureDateChange}
+          onReturnDateChange={onReturnDateChange}
+        />
+      );
+
+      // Step 1: User clicks return date field first
+      const returnDateField = screen.getByText("返回日期").closest("div");
+      await user.click(returnDateField!);
+
+      // Step 2: User closes calendar without selecting
+      await user.keyboard("{Escape}");
+
+      vi.clearAllMocks();
+
+      // Step 3: User changes mind and clicks departure date field
+      const departureDateField = screen.getByText("出发日期").closest("div");
+      await user.click(departureDateField!);
+
+      // Step 4: User selects a new departure date
+      await clickDateButton(user, dates.sevenDaysLater);
+
+      // Expected: departure date should be updated
+      const actualDeparture = onDepartureDateChange.mock.calls[0]?.[0];
+      expect(actualDeparture).toEqual(dates.sevenDaysLater);
+      // Return date should not be updated
+      expect(onReturnDateChange).not.toHaveBeenCalled();
+    });
+
+    // Scenario 4: User switches from departure to return
+    it("should update return when user switches from departure field to return field", async () => {
+      const dates = getTestDates();
+      const user = userEvent.setup();
+      const initialDeparture = dates.fiveDaysLater;
+      const initialReturn = dates.tenDaysLater;
+      const onDepartureDateChange = vi.fn();
+      const onReturnDateChange = vi.fn();
+
+      render(
+        <DateSelector
+          {...defaultProps}
+          tripType="round-trip"
+          departureDate={initialDeparture}
+          returnDate={initialReturn}
+          onDepartureDateChange={onDepartureDateChange}
+          onReturnDateChange={onReturnDateChange}
+        />
+      );
+
+      // Step 1: User clicks departure date field first
+      const departureDateField = screen.getByText("出发日期").closest("div");
+      await user.click(departureDateField!);
+
+      // Step 2: User closes calendar without selecting
+      await user.keyboard("{Escape}");
+
+      vi.clearAllMocks();
+
+      // Step 3: User changes mind and clicks return date field
+      const returnDateField = screen.getByText("返回日期").closest("div");
+      await user.click(returnDateField!);
+
+      // Step 4: User selects a new return date
+      await clickDateButton(user, dates.twelveDaysLater);
+
+      // Expected: return date should be updated
+      const actualReturn = onReturnDateChange.mock.calls[0]?.[0];
+      expect(actualReturn).toEqual(dates.twelveDaysLater);
+      // Departure date should not be updated
+      expect(onDepartureDateChange).not.toHaveBeenCalled();
+    });
+
+    // Scenario 5: User modifies departure multiple times
+    it("should update departure correctly when user modifies it multiple times", async () => {
+      const dates = getTestDates();
+      const user = userEvent.setup();
+      const initialDeparture = dates.fiveDaysLater;
+      const initialReturn = dates.tenDaysLater;
+      const onDepartureDateChange = vi.fn();
+      const onReturnDateChange = vi.fn();
+
+      render(
+        <DateSelector
+          {...defaultProps}
+          tripType="round-trip"
+          departureDate={initialDeparture}
+          returnDate={initialReturn}
+          onDepartureDateChange={onDepartureDateChange}
+          onReturnDateChange={onReturnDateChange}
+        />
+      );
+
+      // First modification
+      let departureDateField = screen.getByText("出发日期").closest("div");
+      await user.click(departureDateField!);
+      await clickDateButton(user, dates.sixDaysLater);
+
+      expect(onDepartureDateChange).toHaveBeenCalledWith(dates.sixDaysLater);
+
+      vi.clearAllMocks();
+
+      // Second modification
+      departureDateField = screen.getByText("出发日期").closest("div");
+      await user.click(departureDateField!);
+      await clickDateButton(user, dates.sevenDaysLater);
+
+      expect(onDepartureDateChange).toHaveBeenCalledWith(dates.sevenDaysLater);
+      // Return date should never be touched
+      expect(onReturnDateChange).not.toHaveBeenCalled();
+    });
+
+    // Scenario 6: User modifies return multiple times
+    it("should update return correctly when user modifies it multiple times", async () => {
+      const dates = getTestDates();
+      const user = userEvent.setup();
+      const initialDeparture = dates.fiveDaysLater;
+      const initialReturn = dates.tenDaysLater;
+      const onDepartureDateChange = vi.fn();
+      const onReturnDateChange = vi.fn();
+
+      render(
+        <DateSelector
+          {...defaultProps}
+          tripType="round-trip"
+          departureDate={initialDeparture}
+          returnDate={initialReturn}
+          onDepartureDateChange={onDepartureDateChange}
+          onReturnDateChange={onReturnDateChange}
+        />
+      );
+
+      // First modification
+      let returnDateField = screen.getByText("返回日期").closest("div");
+      await user.click(returnDateField!);
+      await clickDateButton(user, dates.elevenDaysLater);
+
+      expect(onReturnDateChange).toHaveBeenCalledWith(dates.elevenDaysLater);
+
+      vi.clearAllMocks();
+
+      // Second modification
+      returnDateField = screen.getByText("返回日期").closest("div");
+      await user.click(returnDateField!);
+      await clickDateButton(user, dates.thirteenDaysLater);
+
+      expect(onReturnDateChange).toHaveBeenCalledWith(dates.thirteenDaysLater);
+      // Departure date should never be touched
+      expect(onDepartureDateChange).not.toHaveBeenCalled();
+    });
+
+    // Scenario 7: Alternating between departure and return fields
+    it("should handle alternating clicks between departure and return fields", async () => {
+      const dates = getTestDates();
+      const user = userEvent.setup();
+      const initialDeparture = dates.fiveDaysLater;
+      const initialReturn = dates.tenDaysLater;
+      const onDepartureDateChange = vi.fn();
+      const onReturnDateChange = vi.fn();
+
+      render(
+        <DateSelector
+          {...defaultProps}
+          tripType="round-trip"
+          departureDate={initialDeparture}
+          returnDate={initialReturn}
+          onDepartureDateChange={onDepartureDateChange}
+          onReturnDateChange={onReturnDateChange}
+        />
+      );
+
+      // Click sequence: Departure -> Return -> Departure -> Return
+
+      // 1st: Click departure
+      let departureDateField = screen.getByText("出发日期").closest("div");
+      await user.click(departureDateField!);
+      await clickDateButton(user, dates.sixDaysLater);
+      expect(onDepartureDateChange).toHaveBeenCalledWith(dates.sixDaysLater);
+
+      vi.clearAllMocks();
+
+      // 2nd: Click return
+      let returnDateField = screen.getByText("返回日期").closest("div");
+      await user.click(returnDateField!);
+      await clickDateButton(user, dates.elevenDaysLater);
+      expect(onReturnDateChange).toHaveBeenCalledWith(dates.elevenDaysLater);
+      expect(onDepartureDateChange).not.toHaveBeenCalled();
+
+      vi.clearAllMocks();
+
+      // 3rd: Click departure again
+      departureDateField = screen.getByText("出发日期").closest("div");
+      await user.click(departureDateField!);
+      await clickDateButton(user, dates.sevenDaysLater);
+      expect(onDepartureDateChange).toHaveBeenCalledWith(dates.sevenDaysLater);
+      expect(onReturnDateChange).not.toHaveBeenCalled();
+
+      vi.clearAllMocks();
+
+      // 4th: Click return again
+      returnDateField = screen.getByText("返回日期").closest("div");
+      await user.click(returnDateField!);
+      await clickDateButton(user, dates.twelveDaysLater);
+      expect(onReturnDateChange).toHaveBeenCalledWith(dates.twelveDaysLater);
+      expect(onDepartureDateChange).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/_components/flights/search/date-selector/date-selector.tsx
+++ b/app/_components/flights/search/date-selector/date-selector.tsx
@@ -61,6 +61,7 @@ export function DateSelector({
           tripDuration={tripDuration}
           calendarOpen={calendarOpen}
           onCalendarOpenChange={setCalendarOpen}
+          activeField={activeField}
           onDepartureClick={handleDepartureClick}
           onReturnClick={handleReturnClick}
           onDateSelect={handleDateSelect}

--- a/app/_components/flights/search/date-selector/round-trip-selector.tsx
+++ b/app/_components/flights/search/date-selector/round-trip-selector.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { type ActiveField } from "@/hooks/use-date-selector";
 
 import { DateDisplay } from "./date-display";
 
@@ -19,6 +20,7 @@ export interface RoundTripSelectorProps {
   tripDuration: number;
   calendarOpen: boolean;
   onCalendarOpenChange: (open: boolean) => void;
+  activeField: ActiveField;
   onDepartureClick: () => void;
   onReturnClick: () => void;
   onDateSelect: (date: Date | DateRange | undefined) => void;
@@ -32,6 +34,7 @@ export function RoundTripSelector({
   tripDuration,
   calendarOpen,
   onCalendarOpenChange,
+  activeField,
   onDepartureClick,
   onReturnClick,
   onDateSelect,
@@ -41,11 +44,16 @@ export function RoundTripSelector({
     <DropdownMenu open={calendarOpen} onOpenChange={onCalendarOpenChange}>
       <div className="relative flex items-stretch border rounded-lg overflow-hidden bg-background hover:bg-accent/50 transition-colors">
         {/* Departure Date Section */}
-        <DropdownMenuTrigger asChild>
-          <div
-            className="flex-1 px-4 py-3 cursor-pointer"
-            onClick={onDepartureClick}
-          >
+        <DropdownMenuTrigger
+          asChild
+          onPointerDown={() => onDepartureClick()}
+          onKeyDown={event => {
+            if (event.key === "Enter" || event.key === " ") {
+              onDepartureClick();
+            }
+          }}
+        >
+          <div className="flex-1 px-4 py-3 cursor-pointer">
             <div className="text-xs text-muted-foreground mb-1">出发日期</div>
             <div className="flex items-baseline gap-2">
               <DateDisplay date={departureDate} today={today} />
@@ -67,11 +75,16 @@ export function RoundTripSelector({
         </div>
 
         {/* Return Date Section */}
-        <DropdownMenuTrigger asChild>
-          <div
-            className="flex-1 px-4 py-3 cursor-pointer"
-            onClick={onReturnClick}
-          >
+        <DropdownMenuTrigger
+          asChild
+          onPointerDown={() => onReturnClick()}
+          onKeyDown={event => {
+            if (event.key === "Enter" || event.key === " ") {
+              onReturnClick();
+            }
+          }}
+        >
+          <div className="flex-1 px-4 py-3 cursor-pointer">
             <div className="text-xs text-muted-foreground mb-1 text-right">
               返回日期
             </div>
@@ -91,11 +104,13 @@ export function RoundTripSelector({
           mode="range"
           defaultMonth={departureDate || new Date()}
           selected={
-            departureDate && returnDate
-              ? { from: departureDate, to: returnDate }
-              : departureDate
-                ? { from: departureDate, to: undefined }
-                : undefined
+            activeField === "departure"
+              ? undefined
+              : departureDate && returnDate
+                ? { from: departureDate, to: returnDate }
+                : departureDate
+                  ? { from: departureDate, to: undefined }
+                  : undefined
           }
           onSelect={onDateSelect}
           numberOfMonths={2}

--- a/app/_hooks/use-date-selector.ts
+++ b/app/_hooks/use-date-selector.ts
@@ -75,48 +75,40 @@ export function useDateSelector({
         const range = date as DateRange | undefined;
 
         if (activeField === "departure") {
-          if (range?.from && range?.to) {
+          if (range?.from) {
             onDepartureDateChange(range.from);
-            onReturnDateChange(range.to);
-            setCalendarOpen(false);
-          } else if (range?.from && !range?.to) {
-            const newDepartureDate = range.from;
-            onDepartureDateChange(newDepartureDate);
-
-            if (returnDate) {
-              if (newDepartureDate <= returnDate) {
-                setCalendarOpen(false);
-              } else {
-                onReturnDateChange(newDepartureDate);
-              }
-            } else {
-              onReturnDateChange(newDepartureDate);
+            if (range.to && range.to.getTime() !== range.from.getTime()) {
+              onReturnDateChange(range.to);
             }
           }
-        } else {
-          if (range?.from && range?.to) {
-            onDepartureDateChange(range.from);
-            onReturnDateChange(range.to);
-            setCalendarOpen(false);
-          } else if (range?.from && !range?.to) {
-            const newReturnDate = range.from;
-
-            if (departureDate) {
-              if (newReturnDate >= departureDate) {
-                onReturnDateChange(newReturnDate);
-                setCalendarOpen(false);
-              } else {
-                onDepartureDateChange(newReturnDate);
-                onReturnDateChange(departureDate);
-                setCalendarOpen(false);
-              }
-            } else {
-              onDepartureDateChange(newReturnDate);
-              onReturnDateChange(newReturnDate);
-              setCalendarOpen(false);
-            }
-          }
+          setCalendarOpen(false);
+          return;
         }
+
+        const newReturnDate = range?.to ?? range?.from;
+
+        if (!newReturnDate) {
+          return;
+        }
+
+        // If no departure yet, mirror return into both
+        if (!departureDate) {
+          onDepartureDateChange(newReturnDate);
+          onReturnDateChange(newReturnDate);
+          setCalendarOpen(false);
+          return;
+        }
+
+        if (newReturnDate >= departureDate) {
+          onReturnDateChange(newReturnDate);
+          setCalendarOpen(false);
+          return;
+        }
+
+        // Swap when selecting an earlier return
+        onDepartureDateChange(newReturnDate);
+        onReturnDateChange(departureDate);
+        setCalendarOpen(false);
       } else {
         if (date && !(date as DateRange).from) {
           if (activeField === "departure") {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -17,9 +17,31 @@ if (!process.env.DATABASE_URL) {
 
 const logger = createScopedLogger({ module: "db" });
 
+// Merge the multi-line drizzle-query-logger output into one ANSI-free message.
+const buildDrizzleLogMessage = (() => {
+  const ANSI_ESCAPE_REGEX = /\u001b\[[0-9;]*m/g;
+  let buffer: string[] = [];
+
+  return (message: string) => {
+    const cleanedMessage = message.replace(ANSI_ESCAPE_REGEX, "").trimEnd();
+    if (!cleanedMessage) return;
+
+    if (cleanedMessage.startsWith("╭─")) {
+      buffer = [];
+    }
+
+    buffer.push(cleanedMessage);
+
+    if (cleanedMessage.startsWith("╰─")) {
+      logger.debug(`[Drizzle] query\n${buffer.join("\n")}`);
+      buffer = [];
+    }
+  };
+})();
+
 const dbLogger = new EnhancedQueryLogger({
   log: message => {
-    logger.debug({ sql: message }, "[Drizzle] query");
+    buildDrizzleLogMessage(message);
   },
 });
 


### PR DESCRIPTION
## 描述

1.  **解决了 `DropdownMenuTrigger` 的交互问题**：当 `asChild` 属性被使用时，`DropdownMenuTrigger` 会阻止 `onClick` 事件的传播，导致 `activeField`（当前正在选择的日期字段，例如出发日期或返回日期）无法正确更新。通过改用 `onPointerDown` 和 `onKeyDown` 事件处理器，确保了 `activeField` 在用户点击出发日期或返回日期输入框时能够正确设置。
2.  **优化了往返日期选择逻辑**：改进了 `useDateSelector` hook 中 `handleRoundTripSelect` 函数的日期处理逻辑，使其在用户选择往返日期时，能够更准确地更新出发日期和返回日期，并正确处理日期交换（当选择的返回日期早于出发日期时）等边缘情况。
3.  **增加了全面的测试覆盖**：新增了多个测试用例，覆盖了用户首次点击、在出发和返回字段之间切换、多次修改同一字段以及交替点击等复杂交互场景，确保了修复的有效性和稳定性。

## 相关问题

close #193 

## 变更类型

- [x] Bug 修复（不会破坏现有功能的非破坏性变更）
- [ ] 新功能（添加功能的非破坏性变更）
- [ ] 破坏性变更（会导致现有功能无法正常工作的修复或功能）
- [ ] 文档更新
- [ ] 性能改进
- [ ] 代码重构
- [ ] CI/CD 改进