### PR TITLE
feat: implement forget password function

### DIFF
--- a/app/(frontend)/(without-sidebar)/auth/forgot-password/page.client.tsx
+++ b/app/(frontend)/(without-sidebar)/auth/forgot-password/page.client.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { CheckCircle2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useRef, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import OtpInput from "@/components/auth/forms/otp-input";
+import PasswordSetupForm from "@/components/auth/forms/password-setup";
+import {
+  type TurnstileInstance,
+  TurnstileWidget,
+} from "@/components/auth/turnstile";
+import { Stepper, type StepperStep } from "@/components/common";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { useForgotPasswordFlow } from "@/hooks/use-forgot-password-flow";
+import type { FetchOptions } from "@/types/http";
+import {
+  type ForgotPasswordAccountData,
+  forgotPasswordAccountSchema,
+} from "@/types/validations";
+
+const steps: StepperStep[] = [
+  {
+    id: "account",
+    label: "验证账号",
+    description: "输入手机号或邮箱",
+  },
+  {
+    id: "verify",
+    label: "验证身份",
+    description: "输入验证码",
+  },
+  {
+    id: "reset",
+    label: "重置密码",
+    description: "设置新密码",
+  },
+];
+
+export default function ForgotPasswordPageClient() {
+  const router = useRouter();
+  const turnstileRef = useRef<TurnstileInstance>(null);
+  const [isVerifyingCaptcha, setIsVerifyingCaptcha] = useState(false);
+
+  const {
+    currentStep,
+    maskedAccount,
+    countdown,
+    otp,
+    setOtp,
+    isLoading,
+    isResetting,
+    hasCompleted,
+    handleAccountSubmit,
+    handleVerifyOtp,
+    handleResendOtp,
+    handleResetPassword,
+  } = useForgotPasswordFlow();
+
+  const accountForm = useForm<ForgotPasswordAccountData>({
+    resolver: zodResolver(forgotPasswordAccountSchema),
+    defaultValues: {
+      account: "",
+    },
+  });
+
+  const handleWithCaptcha = async <T,>(
+    action: (fetchOptions: FetchOptions) => Promise<T>
+  ): Promise<T | undefined> => {
+    setIsVerifyingCaptcha(true);
+    try {
+      const token = await turnstileRef.current?.getResponsePromise();
+
+      if (!token) {
+        toast.error("人机验证失败，请重试");
+        return undefined;
+      }
+
+      const fetchOptions: FetchOptions = {
+        headers: {
+          "x-captcha-token": token,
+        },
+      };
+
+      return await action(fetchOptions);
+    } finally {
+      setIsVerifyingCaptcha(false);
+      turnstileRef.current?.reset();
+    }
+  };
+
+  const onAccountSubmit = async (data: ForgotPasswordAccountData) => {
+    await handleWithCaptcha(fetchOptions =>
+      handleAccountSubmit(data.account, fetchOptions)
+    );
+  };
+
+  const handleSendOtp = async () => {
+    await handleWithCaptcha(fetchOptions => handleResendOtp(fetchOptions));
+  };
+
+  const handleVerifyClick = () => {
+    handleVerifyOtp(otp);
+  };
+
+  const handleFinish = async (passwordData: {
+    password: string;
+    confirmPassword: string;
+  }) => {
+    await handleResetPassword(passwordData);
+  };
+
+  const isBusy = isLoading || isVerifyingCaptcha;
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full space-y-8">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-foreground">找回密码</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            通过手机号或邮箱验证身份后重置登录密码
+          </p>
+        </div>
+
+        <Stepper steps={steps} currentStep={currentStep} variant="compact" />
+
+        {currentStep === 1 && (
+          <Form {...accountForm}>
+            <form
+              onSubmit={accountForm.handleSubmit(onAccountSubmit)}
+              className="space-y-6"
+            >
+              <div className="space-y-4">
+                <FormField
+                  control={accountForm.control}
+                  name="account"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-sm font-medium text-foreground">
+                        账号
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          placeholder="国内手机号/邮箱"
+                          className="h-12"
+                          disabled={isBusy}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <Button
+                type="submit"
+                className="w-full h-12 bg-secondary text-secondary-foreground hover:bg-secondary/90 font-medium"
+                disabled={isBusy}
+              >
+                {isBusy ? "发送中..." : "下一步，发送验证码"}
+              </Button>
+            </form>
+          </Form>
+        )}
+
+        {currentStep === 2 && (
+          <div className="space-y-6">
+            <div className="p-3 bg-muted border border-border rounded-md">
+              <p className="text-sm text-foreground">
+                验证码已发送至：{" "}
+                <span className="font-mono">
+                  {maskedAccount ?? "请检查账号"}
+                </span>
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
+                如未收到，可在倒计时结束后重新发送
+              </p>
+            </div>
+
+            <OtpInput
+              value={otp}
+              onChange={setOtp}
+              onSendOtp={handleSendOtp}
+              countdown={countdown}
+              isLoading={isLoading}
+              isVerifying={isVerifyingCaptcha}
+              placeholder="6位数字验证码"
+            />
+
+            <Button
+              type="button"
+              className="w-full h-12 bg-secondary text-secondary-foreground hover:bg-secondary/90 font-medium"
+              onClick={handleVerifyClick}
+              disabled={isBusy}
+            >
+              {isBusy ? "验证中..." : "下一步，验证"}
+            </Button>
+          </div>
+        )}
+
+        {currentStep === 3 && (
+          <>
+            {!hasCompleted ? (
+              <PasswordSetupForm
+                onSubmit={handleFinish}
+                isLoading={isResetting}
+                maskedIdentifier={maskedAccount ?? undefined}
+                submitButtonText="完成"
+                showHelpLink={false}
+              />
+            ) : (
+              <div className="text-center space-y-4 py-8 border border-border rounded-lg">
+                <div className="flex justify-center">
+                  <CheckCircle2 className="h-12 w-12 text-green-500" />
+                </div>
+                <h3 className="text-lg font-semibold text-foreground">
+                  密码重置成功
+                </h3>
+                <p className="text-sm text-muted-foreground">
+                  重置密码成功，请使用新密码登录
+                </p>
+                <Button
+                  className="w-full h-11"
+                  onClick={() => router.push("/auth/sign-in")}
+                >
+                  去登录
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+
+        <TurnstileWidget
+          ref={turnstileRef}
+          action="forgot-password"
+          size="invisible"
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/(frontend)/(without-sidebar)/auth/forgot-password/page.tsx
+++ b/app/(frontend)/(without-sidebar)/auth/forgot-password/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+
+import ForgotPasswordPageClient from "./page.client";
+
+export const metadata: Metadata = {
+  title: "找回密码 - Nomad",
+};
+
+export default function ForgotPasswordPage() {
+  return <ForgotPasswordPageClient />;
+}

--- a/app/_actions/auth.ts
+++ b/app/_actions/auth.ts
@@ -229,6 +229,63 @@ export async function sendEmailOtpAction(
 }
 
 /**
+ * Send phone OTP for password reset via server boundary.
+ */
+export async function sendResetPhoneOtpAction(
+  phoneNumber: string,
+  fetchOptions?: FetchOptions
+): Promise<ActionResult> {
+  const captchaResult = ensureCaptcha(fetchOptions);
+  if (captchaResult) {
+    return captchaResult;
+  }
+
+  try {
+    const headersList = await buildHeaders(fetchOptions);
+    await auth.api.requestPasswordResetPhoneNumber({
+      body: { phoneNumber },
+      headers: headersList,
+    });
+    return { success: true, data: undefined };
+  } catch (error) {
+    logger.error({ error }, "Send reset phone OTP failed");
+    return {
+      success: false,
+      error: "该账号未注册，请检查后重试",
+    };
+  }
+}
+
+/**
+ * Send email OTP for password reset via server boundary.
+ */
+export async function sendResetEmailOtpAction(
+  email: string,
+  fetchOptions?: FetchOptions
+): Promise<ActionResult> {
+  const captchaResult = ensureCaptcha(fetchOptions);
+  if (captchaResult) {
+    return captchaResult;
+  }
+
+  try {
+    const headersList = await buildHeaders(fetchOptions);
+    await auth.api.forgetPasswordEmailOTP({
+      body: { email },
+      headers: headersList,
+    });
+
+    return { success: true, data: undefined };
+  } catch (error) {
+    logger.error({ error }, "Send reset email OTP failed");
+    return {
+      success: false,
+      error: "该账号未注册，请检查后重试",
+    };
+  }
+}
+
+/**
  * Verify email OTP (for verification flows).
  */
 export async function verifyEmailOtpAction(
@@ -251,6 +308,59 @@ export async function verifyEmailOtpAction(
     return {
       success: false,
       error: "验证码错误，请重试",
+    };
+  }
+}
+
+/**
+ * Reset password using OTP for phone or email accounts.
+ */
+export async function resetPasswordWithOtpAction(
+  data: { account: string; otp: string; newPassword: string },
+  fetchOptions?: FetchOptions
+): Promise<ActionResult> {
+  const { isPhone, isEmail, account } = resolveAccountType(data.account);
+
+  if (!isPhone && !isEmail) {
+    return { success: false, error: "请输入正确的手机号或邮箱格式" };
+  }
+
+  try {
+    const headersList = await buildHeaders(fetchOptions);
+
+    if (isPhone) {
+      await auth.api.resetPasswordPhoneNumber({
+        body: {
+          phoneNumber: account,
+          otp: data.otp,
+          newPassword: data.newPassword,
+        },
+        headers: headersList,
+      });
+    } else {
+      await auth.api.resetPasswordEmailOTP({
+        body: {
+          email: account,
+          otp: data.otp,
+          password: data.newPassword,
+        },
+        headers: headersList,
+      });
+    }
+
+    return { success: true, data: undefined };
+  } catch (error) {
+    logger.error({ error }, "Reset password with OTP failed");
+    const message =
+      error instanceof Error ? error.message.toLowerCase() : undefined;
+
+    if (message?.includes("expire")) {
+      return { success: false, error: "验证码已过期，请重新获取" };
+    }
+
+    return {
+      success: false,
+      error: "验证码错误，请重新输入",
     };
   }
 }

--- a/app/_hooks/use-forgot-password-flow.ts
+++ b/app/_hooks/use-forgot-password-flow.ts
@@ -1,0 +1,247 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import {
+  resetPasswordWithOtpAction,
+  sendResetEmailOtpAction,
+  sendResetPhoneOtpAction,
+} from "@/app/_actions/auth";
+import { useOtpCountdown } from "@/hooks/use-otp-countdown";
+import { maskEmail, maskPhoneNumber } from "@/lib/security";
+import { validateAccount } from "@/lib/validation";
+import type { ActionResult } from "@/types/common";
+import type { FetchOptions } from "@/types/http";
+import type { PasswordSetupData } from "@/types/validations";
+import { accountSchema, otpCodeSchema } from "@/types/validations";
+
+type ResetMethod = "phone" | "email";
+
+export interface UseForgotPasswordFlowReturn {
+  currentStep: number;
+  method: ResetMethod | null;
+  maskedAccount: string | null;
+  countdown: number;
+  otp: string;
+  isLoading: boolean;
+  isResetting: boolean;
+  hasCompleted: boolean;
+  setOtp: (otp: string) => void;
+  handleAccountSubmit: (
+    account: string,
+    fetchOptions?: FetchOptions
+  ) => Promise<ActionResult>;
+  handleVerifyOtp: (otp: string) => boolean;
+  handleResendOtp: (fetchOptions?: FetchOptions) => Promise<boolean>;
+  handleResetPassword: (data: PasswordSetupData) => Promise<void>;
+}
+
+/**
+ * Hook to orchestrate forgot-password flow across three steps:
+ * 1) Verify account & send OTP (Turnstile required)
+ * 2) Capture OTP and move to reset
+ * 3) Reset password with OTP
+ */
+export function useForgotPasswordFlow(): UseForgotPasswordFlowReturn {
+  const [currentStep, setCurrentStep] = useState(1);
+  const [method, setMethod] = useState<ResetMethod | null>(null);
+  const [account, setAccount] = useState("");
+  const [otp, setOtp] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isResetting, setIsResetting] = useState(false);
+  const [hasCompleted, setHasCompleted] = useState(false);
+  const {
+    countdown,
+    start: startCountdown,
+    reset: resetCountdown,
+  } = useOtpCountdown();
+
+  const maskedAccount = useMemo(() => {
+    if (!account || !method) return null;
+    return method === "phone" ? maskPhoneNumber(account) : maskEmail(account);
+  }, [account, method]);
+
+  const sendOtp = async (
+    targetAccount: string,
+    targetMethod: ResetMethod,
+    fetchOptions?: FetchOptions
+  ): Promise<ActionResult> => {
+    if (targetMethod === "phone") {
+      return sendResetPhoneOtpAction(targetAccount, fetchOptions);
+    }
+
+    return sendResetEmailOtpAction(targetAccount, fetchOptions);
+  };
+
+  /**
+   * Step 1: Validate account and send OTP (Turnstile guarded)
+   */
+  const handleAccountSubmit = async (
+    rawAccount: string,
+    fetchOptions?: FetchOptions
+  ): Promise<ActionResult> => {
+    const parsedAccount = accountSchema.safeParse(rawAccount.trim());
+
+    if (!parsedAccount.success) {
+      const message =
+        parsedAccount.error.issues?.[0]?.message || parsedAccount.error.message;
+      toast.error(message || "请输入正确的手机号或邮箱格式");
+      return { success: false, error: message };
+    }
+
+    // Normalize + validate type
+    const trimmedAccount = parsedAccount.data.replace(/^\+86/, "");
+    const { isPhone, isEmail } = validateAccount(trimmedAccount);
+
+    if (!isPhone && !isEmail) {
+      const message = "请输入正确的手机号或邮箱格式";
+      toast.error(message);
+      return { success: false, error: message };
+    }
+
+    setIsLoading(true);
+
+    try {
+      const targetMethod: ResetMethod = isPhone ? "phone" : "email";
+      const sendResult = await sendOtp(
+        trimmedAccount,
+        targetMethod,
+        fetchOptions
+      );
+
+      if (!sendResult.success) {
+        toast.error(sendResult.error || "发送验证码失败，请重试");
+        return sendResult;
+      }
+
+      // Reset flow state for new account
+      setAccount(trimmedAccount);
+      setMethod(targetMethod);
+      setOtp("");
+      setHasCompleted(false);
+      setCurrentStep(2);
+      resetCountdown();
+      startCountdown();
+
+      toast.success("验证码已发送，请查收");
+      return { success: true, data: undefined };
+    } catch {
+      const message = "网络错误，请稍后重试";
+      toast.error(message);
+      return { success: false, error: message };
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  /**
+   * Step 2: Store OTP locally (format validation only)
+   */
+  const handleVerifyOtp = (inputOtp: string): boolean => {
+    const parsedOtp = otpCodeSchema.safeParse(inputOtp.trim());
+
+    if (!parsedOtp.success) {
+      const message =
+        parsedOtp.error.issues?.[0]?.message || parsedOtp.error.message;
+      toast.error(message || "请输入6位数字验证码");
+      return false;
+    }
+
+    setOtp(parsedOtp.data);
+    setCurrentStep(3);
+    return true;
+  };
+
+  /**
+   * Resend OTP with Turnstile verification
+   */
+  const handleResendOtp = async (
+    fetchOptions?: FetchOptions
+  ): Promise<boolean> => {
+    if (!account || !method) {
+      toast.error("请先填写并验证账号");
+      return false;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const result = await sendOtp(account, method, fetchOptions);
+
+      if (!result.success) {
+        toast.error(result.error || "发送验证码失败，请重试");
+        return false;
+      }
+
+      resetCountdown();
+      startCountdown();
+      toast.success("验证码已发送，请查收");
+      return true;
+    } catch {
+      toast.error("网络错误，请稍后重试");
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  /**
+   * Step 3: Reset password using OTP
+   */
+  const handleResetPassword = async (
+    data: PasswordSetupData
+  ): Promise<void> => {
+    if (!account || !method) {
+      toast.error("请先完成账号验证");
+      setCurrentStep(1);
+      return;
+    }
+
+    const parsedOtp = otpCodeSchema.safeParse(otp);
+    if (!parsedOtp.success) {
+      toast.error("请先输入收到的验证码");
+      setCurrentStep(2);
+      return;
+    }
+
+    setIsResetting(true);
+
+    try {
+      const result = await resetPasswordWithOtpAction({
+        account,
+        otp: parsedOtp.data,
+        newPassword: data.password,
+      });
+
+      if (!result.success) {
+        toast.error(result.error || "重置密码失败，请重试");
+        setCurrentStep(2);
+        return;
+      }
+
+      setHasCompleted(true);
+      toast.success("重置密码成功，请使用新密码登录");
+    } catch {
+      toast.error("网络错误，请稍后重试");
+    } finally {
+      setIsResetting(false);
+    }
+  };
+
+  return {
+    currentStep,
+    method,
+    maskedAccount,
+    countdown,
+    otp,
+    isLoading,
+    isResetting,
+    hasCompleted,
+    setOtp,
+    handleAccountSubmit,
+    handleVerifyOtp,
+    handleResendOtp,
+    handleResetPassword,
+  };
+}

--- a/src/infra/auth/better-auth.plugin.ts
+++ b/src/infra/auth/better-auth.plugin.ts
@@ -22,7 +22,12 @@ export const auth = betterAuth({
     captcha({
       provider: "cloudflare-turnstile",
       secretKey: process.env.TURNSTILE_SECRET_KEY ?? "",
-      endpoints: ["/phone-number/send-otp", "/email-otp/send-verification-otp"],
+      endpoints: [
+        "/phone-number/send-otp",
+        "/email-otp/send-verification-otp",
+        "/phone-number/request-password-reset",
+        "/forget-password/email-otp",
+      ],
     }),
     phoneNumber({
       sendOTP: async ({ phoneNumber, code }) => {

--- a/src/types/validations/auth.ts
+++ b/src/types/validations/auth.ts
@@ -101,6 +101,28 @@ export const passwordSetupSchema = z
     path: ["confirmPassword"],
   });
 
+// Forgot password schemas
+export const forgotPasswordAccountSchema = z.object({
+  account: accountSchema,
+});
+
+export const forgotPasswordVerifySchema = z.object({
+  account: accountSchema,
+  otp: otpCodeSchema,
+});
+
+export const forgotPasswordResetSchema = z
+  .object({
+    account: accountSchema,
+    otp: otpCodeSchema,
+    password: passwordSchema,
+    confirmPassword: z.string(),
+  })
+  .refine(data => data.password === data.confirmPassword, {
+    message: "两次输入的密码不一致",
+    path: ["confirmPassword"],
+  });
+
 // Security/Update schemas (without agreedToTerms)
 export const updatePhoneSchema = z.object({
   phoneNumber: phoneNumberSchema,
@@ -162,6 +184,13 @@ export type PasswordSetupData = z.infer<typeof passwordSetupSchema>;
 export type UpdatePhoneData = z.infer<typeof updatePhoneSchema>;
 export type UpdateEmailData = z.infer<typeof updateEmailSchema>;
 export type ChangePasswordData = z.infer<typeof changePasswordSchema>;
+export type ForgotPasswordAccountData = z.infer<
+  typeof forgotPasswordAccountSchema
+>;
+export type ForgotPasswordVerifyData = z.infer<
+  typeof forgotPasswordVerifySchema
+>;
+export type ForgotPasswordResetData = z.infer<typeof forgotPasswordResetSchema>;
 
 // Legacy types for backward compatibility (deprecated)
 export type PhoneLoginData = z.infer<typeof phoneLoginSchema>;


### PR DESCRIPTION
## 描述

本 PR 实现了用户“忘记密码”的完整功能流程。用户现在可以通过邮箱请求重置密码，验证 OTP（一次性密码），并设置新密码。

该实现包含以下 3 个主要功能：

1.  **feat(api): 添加忘记密码后端逻辑与 Server Actions**
    *   在 `app/_actions/auth.ts` 中增加了发送 OTP 邮件和重置密码的 Server Actions。
    *   实现了后端验证逻辑，确保 OTP 的有效性和过期时间处理。

2.  **feat(ui): 创建忘记密码相关 UI 组件**
    *   新增了用于输入邮箱、填写 OTP 和设置新密码的表单组件。
    *   更新了登录页面的 UI，增加了“忘记密码”的入口链接。

3.  **feat(hooks): 集成忘记密码状态管理**
    *   实现了 `use-forgot-password-flow.ts` hook，用于管理多步骤表单的状态（请求 -> 验证 -> 重置）。
    *   完成了前端组件与后端 Server Actions 的对接与错误处理。

## 相关问题

Resolves #195 

## 变更类型

- [ ] Bug 修复（不会破坏现有功能的非破坏性变更）
- [x] 新功能（添加功能的非破坏性变更）
- [ ] 破坏性变更（会导致现有功能无法正常工作的修复或功能）
- [ ] 文档更新
- [ ] 性能改进
- [ ] 代码重构
- [ ] CI/CD 改进

## 截图

<img width="685" height="446" alt="image" src="https://github.com/user-attachments/assets/26aa5096-2aa8-465b-9ea0-fc8b7689b756" />

<img width="649" height="434" alt="image" src="https://github.com/user-attachments/assets/8666c890-c4df-4a16-af3e-d3e3e4e58801" />

<img width="1352" height="1492" alt="image" src="https://github.com/user-attachments/assets/233f62b1-e4bb-419f-a2d2-9e695e8e1e7b" />
