### PR TITLE
refactor(env): add zod validation and type-safe env handling

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -5,7 +5,7 @@
 # Database connection string
 # Format: postgresql://[username]:[password]@[host]:[port]/[database_name]
 # Example: postgresql://user:password@localhost:5432/nomad_db
-DATABASE_URL=postgresql://localhost:5432/nomad_test
+DATABASE_URL=postgresql://postgres:09022004@localhost:5433/nomad
 
 # =============================================================================
 # LOGGING CONFIGURATION (Pino Logger)

--- a/.env.test
+++ b/.env.test
@@ -5,7 +5,7 @@
 # Database connection string
 # Format: postgresql://[username]:[password]@[host]:[port]/[database_name]
 # Example: postgresql://user:password@localhost:5432/nomad_db
-DATABASE_URL=postgresql://postgres:09022004@localhost:5433/nomad
+DATABASE_URL=postgresql://localhost:5432/nomad_test
 
 # =============================================================================
 # LOGGING CONFIGURATION (Pino Logger)

--- a/app/(frontend)/layout.tsx
+++ b/app/(frontend)/layout.tsx
@@ -3,12 +3,13 @@ import "./globals.css";
 import { type ReactNode } from "react";
 
 import { DevUserSwitcher } from "@/components/common";
+import { isDevelopment } from "@/config/env";
 
 export default function FrontendLayout({ children }: { children: ReactNode }) {
   return (
     <>
       {children}
-      {process.env.NODE_ENV === "development" && <DevUserSwitcher />}
+      {isDevelopment() && <DevUserSwitcher />}
     </>
   );
 }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -7,7 +7,7 @@ export const runtime = "edge";
 
 const openai = createOpenAICompatible({
   name: "inkeep",
-  apiKey: process.env.INKEEP_API_KEY,
+  apiKey: process.env.INKEEP_API_KEY ?? "",
   baseURL: "https://api.inkeep.com/v1",
 });
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,17 +1,16 @@
-import { loadEnvConfig } from "@next/env";
 import { defineConfig } from "drizzle-kit";
+import { getDbEnv } from "./src/config/env";
+import { ensureNodeEnvLoaded } from "./src/config/load-env";
 
-// Load environment variables based on NODE_ENV
-// - NODE_ENV=test → loads .env.test
-// - NODE_ENV=development → loads .env.local or .env.development
-// - NODE_ENV=production → loads .env.production
-loadEnvConfig(process.cwd());
+ensureNodeEnvLoaded();
+
+const dbEnv = getDbEnv();
 
 export default defineConfig({
   out: "./drizzle",
   schema: ["./src/db/schema/index.ts"],
   dialect: "postgresql",
   dbCredentials: {
-    url: process.env.DATABASE_URL ?? "",
+    url: dbEnv.DATABASE_URL,
   },
 });

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -7,10 +7,10 @@
  * @see https://nextjs.org/docs/15/app/guides/instrumentation
  */
 
+import { isDevelopment } from "@/config/env";
+
 export async function register() {
-  // Only run in development mode
-  if (process.env.NODE_ENV === "development") {
-    // Only run on server (not in edge runtime)
+  if (isDevelopment()) {
     if (process.env.NEXT_RUNTIME === "nodejs") {
       const { startOrderCancellationTask } = await import("@/infra/background");
       startOrderCancellationTask();

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "next build --turbopack",
     "start": "next start",
     "test": "cross-env NODE_ENV=test vitest",
-    "test:run": "cross-env NODE_ENV=test vitest --run --silent",
+    "test:run": "cross-env NODE_ENV=test vitest --run --silent=true",
     "test:unit": "cross-env NODE_ENV=test vitest --run --project=unit",
     "test:repository": "cross-env NODE_ENV=test vitest --run --project=repository",
     "test:integration": "cross-env NODE_ENV=test vitest --run --project=integration",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,7 +25,9 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. */
-    baseURL: "http://localhost:3000",
+    baseURL: process.env.BASE_PATH
+      ? `http://localhost:3000${process.env.BASE_PATH}`
+      : "http://localhost:3000",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -66,7 +68,10 @@ export default defineConfig({
 
     env: {
       NODE_ENV: "test",
+      LOG_LEVEL: "silent",
+      ENABLE_RESEND: "false",
       ENABLE_ALIYUN_SMS: "false", // Explicitly disable Aliyun SMS in tests
+      BASE_PATH: process.env.BASE_PATH || "",
       // Dummy DATABASE_URL for test environment (not used for actual DB operations)
       DATABASE_URL:
         process.env.DATABASE_URL ||

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,23 +1,310 @@
-/**
- * Checks if the current environment is production.
- * @returns True if NODE_ENV is set to "production"
- */
+import { z } from "zod";
+
+const envSchema = z
+  .object({
+    NODE_ENV: z.enum(["development", "test", "production"]),
+    NEXT_RUNTIME: z.preprocess(val => {
+      if (typeof val === "string" && val.trim() === "") return undefined;
+      return val;
+    }, z.enum(["nodejs", "edge"]).optional()),
+    BASE_PATH: z.string().default(""),
+    LOG_LEVEL: z.preprocess(val => {
+      if (typeof val === "string" && val.trim() === "") return undefined;
+      return val;
+    }, z
+      .union([
+        z.literal("fatal"),
+        z.literal("error"),
+        z.literal("warn"),
+        z.literal("info"),
+        z.literal("debug"),
+        z.literal("trace"),
+        z.literal("silent"),
+      ])
+      .optional()),
+    DATABASE_URL: z.string().min(1),
+    DATABASE_SSL: z.preprocess(val => {
+      if (typeof val === "string") {
+        const s = val.toLowerCase();
+        if (s === "true" || s === "enabled") return true;
+        if (s === "false" || s === "disabled") return false;
+        return undefined;
+      }
+      if (typeof val === "boolean") return val;
+      return undefined;
+    }, z.boolean().optional()),
+    BETTER_AUTH_SECRET: z.preprocess(val => {
+      if (typeof val === "string" && val.trim() === "") return undefined;
+      return val;
+    }, z.string().min(1).optional()),
+    BETTER_AUTH_URL: z.string().min(1).default("http://localhost:3000"),
+    ENABLE_ALIYUN_SMS: z
+      .union([
+        z.literal("enabled"),
+        z.literal("disabled"),
+        z.literal("true"),
+        z.literal("false"),
+        z.literal(""),
+      ])
+      .optional(),
+    ALIBABA_CLOUD_SMS_SIGN_NAME: z.preprocess(val => {
+      if (typeof val === "string" && val.trim() === "") return undefined;
+      return val;
+    }, z.string().min(1).optional()),
+    ALIBABA_CLOUD_SMS_TEMPLATE_CODE: z.preprocess(val => {
+      if (typeof val === "string" && val.trim() === "") return undefined;
+      return val;
+    }, z.string().min(1).optional()),
+    ENABLE_RESEND: z
+      .union([
+        z.literal("enabled"),
+        z.literal("disabled"),
+        z.literal("true"),
+        z.literal("false"),
+        z.literal(""),
+      ])
+      .optional(),
+    RESEND_API_KEY: z.preprocess(val => {
+      if (typeof val === "string" && val.trim() === "") return undefined;
+      return val;
+    }, z.string().min(1).optional()),
+    RESEND_FROM_EMAIL: z.preprocess(val => {
+      if (typeof val === "string" && val.trim() === "") return undefined;
+      return val;
+    }, z.string().min(1).default("onboarding@resend.dev")),
+    NEXT_PUBLIC_TURNSTILE_SITE_KEY: z.preprocess(val => {
+      if (typeof val === "string" && val.trim() === "") return undefined;
+      return val;
+    }, z.string().min(1).default("1x00000000000000000000AA")),
+    TURNSTILE_SECRET_KEY: z.preprocess(val => {
+      if (typeof val === "string" && val.trim() === "") return undefined;
+      return val;
+    }, z.string().min(1).default("1x0000000000000000000000000000000AA")),
+    CRON_SECRET: z.preprocess(val => {
+      if (typeof val === "string" && val.trim() === "") return undefined;
+      return val;
+    }, z.string().min(1).optional()),
+    GITHUB_CLIENT_ID: z.preprocess(val => {
+      if (typeof val === "string" && val.trim() === "") return undefined;
+      return val;
+    }, z.string().min(1).optional()),
+    GITHUB_CLIENT_SECRET: z.preprocess(val => {
+      if (typeof val === "string" && val.trim() === "") return undefined;
+      return val;
+    }, z.string().min(1).optional()),
+  })
+  .superRefine((data, ctx) => {
+    const smsEnabled = (data.ENABLE_ALIYUN_SMS ?? "").toLowerCase();
+    if (smsEnabled === "enabled" || smsEnabled === "true") {
+      if (!data.ALIBABA_CLOUD_SMS_SIGN_NAME) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["ALIBABA_CLOUD_SMS_SIGN_NAME"],
+          message:
+            "ALIBABA_CLOUD_SMS_SIGN_NAME is required when ENABLE_ALIYUN_SMS=enabled",
+        });
+      }
+      if (!data.ALIBABA_CLOUD_SMS_TEMPLATE_CODE) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["ALIBABA_CLOUD_SMS_TEMPLATE_CODE"],
+          message:
+            "ALIBABA_CLOUD_SMS_TEMPLATE_CODE is required when ENABLE_ALIYUN_SMS=enabled",
+        });
+      }
+    }
+    const emailEnabled = (data.ENABLE_RESEND ?? "").toLowerCase();
+    if (emailEnabled === "enabled" || emailEnabled === "true") {
+      if (!data.RESEND_API_KEY) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["RESEND_API_KEY"],
+          message: "RESEND_API_KEY is required when ENABLE_RESEND=enabled",
+        });
+      }
+      if (!data.RESEND_FROM_EMAIL) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["RESEND_FROM_EMAIL"],
+          message: "RESEND_FROM_EMAIL is required when ENABLE_RESEND=enabled",
+        });
+      }
+    }
+  });
+
+export type EnvType = z.infer<typeof envSchema>;
+
+export function getParsedEnv(): EnvType {
+  const parsed = envSchema.parse(process.env as Record<string, unknown>);
+  return parsed as EnvType;
+}
+
+export function getFeatures(): { sms: boolean; email: boolean } {
+  const env = getParsedEnv();
+  const normalize = (v: string | undefined) => {
+    const s = (v ?? "").toLowerCase();
+    if (s === "enabled" || s === "true") return true;
+    if (s === "disabled" || s === "false") return false;
+    return env.NODE_ENV === "production";
+  };
+
+  const sms = normalize(env.ENABLE_ALIYUN_SMS as unknown as string | undefined);
+  if (sms) {
+    const issues: z.ZodIssue[] = [];
+    if (!(env as any).ALIBABA_CLOUD_SMS_SIGN_NAME)
+      issues.push({
+        code: z.ZodIssueCode.custom,
+        path: ["ALIYUN_SMS_SIGN_NAME"],
+        message: "Aliyun SMS requires SIGN_NAME when enabled",
+      });
+    if (!(env as any).ALIBABA_CLOUD_SMS_TEMPLATE_CODE)
+      issues.push({
+        code: z.ZodIssueCode.custom,
+        path: ["ALIYUN_SMS_TEMPLATE_CODE"],
+        message: "Aliyun SMS requires TEMPLATE_CODE when enabled",
+      });
+    if (issues.length) throw new z.ZodError(issues);
+  }
+
+  const email = normalize(env.ENABLE_RESEND as unknown as string | undefined);
+  if (email) {
+    const issues: z.ZodIssue[] = [];
+    if (!env.RESEND_API_KEY)
+      issues.push({
+        code: z.ZodIssueCode.custom,
+        path: ["RESEND_API_KEY"],
+        message: "RESEND_API_KEY is required when ENABLE_RESEND=enabled",
+      });
+    if (!(env as any).RESEND_FROM_EMAIL)
+      issues.push({
+        code: z.ZodIssueCode.custom,
+        path: ["RESEND_FROM_EMAIL"],
+        message: "RESEND_FROM_EMAIL is required when ENABLE_RESEND=enabled",
+      });
+    if (issues.length) throw new z.ZodError(issues);
+  }
+
+  return { sms, email };
+}
+
+// Lightweight feature toggles without strict cross-field validation
+export function getFeatureToggles(): { sms: boolean; email: boolean } {
+  const nodeEnv = process.env.NODE_ENV;
+  const isProd = nodeEnv === "production";
+  const normalize = (v: string | undefined) => {
+    const s = (v ?? "").toLowerCase();
+    if (s === "enabled" || s === "true") return true;
+    if (s === "disabled" || s === "false") return false;
+    return isProd;
+  };
+
+  const sms = normalize(process.env.ENABLE_ALIYUN_SMS);
+  const email = normalize(process.env.ENABLE_RESEND);
+  return { sms, email };
+}
+
 export function isProduction(): boolean {
   return process.env.NODE_ENV === "production";
 }
 
-/**
- * Checks if the current environment is development.
- * @returns True if NODE_ENV is set to "development"
- */
 export function isDevelopment(): boolean {
   return process.env.NODE_ENV === "development";
 }
 
-/**
- * Checks if the current environment is test.
- * @returns True if NODE_ENV is set to "test"
- */
 export function isTest(): boolean {
   return process.env.NODE_ENV === "test";
+}
+
+const dbEnvSchema = z.object({
+  NODE_ENV: z.enum(["development", "test", "production"]).optional(),
+  DATABASE_URL: z.string().min(1),
+  DATABASE_SSL: z.preprocess(val => {
+    if (typeof val === "string") {
+      const s = val.toLowerCase();
+      if (s === "true" || s === "enabled") return true;
+      if (s === "false" || s === "disabled") return false;
+      return undefined;
+    }
+    if (typeof val === "boolean") return val;
+    return undefined;
+  }, z.boolean().optional()),
+});
+
+export type DbEnvType = z.infer<typeof dbEnvSchema>;
+
+export function getDbEnv(): DbEnvType {
+  return dbEnvSchema.parse(process.env as Record<string, unknown>);
+}
+
+export function isNodeRuntime(): boolean {
+  return getParsedEnv().NEXT_RUNTIME === "nodejs";
+}
+
+export function isEdgeRuntime(): boolean {
+  return getParsedEnv().NEXT_RUNTIME === "edge";
+}
+
+export function getLogLevel():
+  | "fatal"
+  | "error"
+  | "warn"
+  | "info"
+  | "debug"
+  | "trace"
+  | "silent" {
+  const env = getParsedEnv();
+  const defaults = {
+    test: "silent",
+    development: "debug",
+    production: "info",
+  } as const;
+  return env.LOG_LEVEL ?? defaults[env.NODE_ENV] ?? "info";
+}
+
+export function isDatabaseSSL(): boolean {
+  const v = getParsedEnv().DATABASE_SSL;
+  return v === true;
+}
+
+export function getDatabaseUrl(): string {
+  return getParsedEnv().DATABASE_URL;
+}
+
+export function getBasePath(): string {
+  return getParsedEnv().BASE_PATH ?? "";
+}
+
+export function hasResendConfig(): boolean {
+  const env = getParsedEnv();
+  const enabled = (
+    env.ENABLE_RESEND as unknown as string | undefined
+  )?.toLowerCase();
+  const isEnabled = enabled === "enabled" || enabled === "true";
+  return Boolean(
+    isEnabled && env.RESEND_API_KEY && (env as any).RESEND_FROM_EMAIL
+  );
+}
+
+export function hasAliyunSmsConfig(): boolean {
+  const env = getParsedEnv();
+  const enabled = (
+    env.ENABLE_ALIYUN_SMS as unknown as string | undefined
+  )?.toLowerCase();
+  const isEnabled = enabled === "enabled" || enabled === "true";
+  return Boolean(
+    isEnabled &&
+      (env as any).ALIBABA_CLOUD_SMS_SIGN_NAME &&
+      (env as any).ALIBABA_CLOUD_SMS_TEMPLATE_CODE
+  );
+}
+
+export function hasTurnstileConfig(): boolean {
+  const env = getParsedEnv();
+  const siteKey =
+    (env as any).TURNSTILE_SITE_KEY ?? env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+  return Boolean(env.TURNSTILE_SECRET_KEY && siteKey);
+}
+
+export function getBetterAuthUrl(): string | undefined {
+  return getParsedEnv().BETTER_AUTH_URL;
 }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -300,9 +300,9 @@ export function hasAliyunSmsConfig(): boolean {
 
 export function hasTurnstileConfig(): boolean {
   const env = getParsedEnv();
-  const siteKey =
-    (env as any).TURNSTILE_SITE_KEY ?? env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
-  return Boolean(env.TURNSTILE_SECRET_KEY && siteKey);
+  return Boolean(
+    env.TURNSTILE_SECRET_KEY && env.NEXT_PUBLIC_TURNSTILE_SITE_KEY
+  );
 }
 
 export function getBetterAuthUrl(): string | undefined {

--- a/src/config/load-env.ts
+++ b/src/config/load-env.ts
@@ -1,0 +1,9 @@
+import { loadEnvConfig } from "@next/env";
+
+let loaded = false;
+
+export function ensureNodeEnvLoaded() {
+  if (loaded) return;
+  loaded = true;
+  loadEnvConfig(process.cwd());
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,7 +1,8 @@
-import { loadEnvConfig } from "@next/env";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { EnhancedQueryLogger } from "drizzle-query-logger";
 
+import { getDbEnv } from "@/config/env";
+import { ensureNodeEnvLoaded } from "@/config/load-env";
 import * as schema from "@/db/schema";
 import { createScopedLogger } from "@/infra/logging/logger";
 
@@ -9,9 +10,12 @@ import { createScopedLogger } from "@/infra/logging/logger";
 // - NODE_ENV=test → loads .env.test
 // - NODE_ENV=development → loads .env.local or .env.development
 // - NODE_ENV=production → loads .env.production
-loadEnvConfig(process.cwd());
+// Next Node Runtime 会自动注入 .env；CLI 场景使用专用加载器显式加载。
+ensureNodeEnvLoaded();
 
-if (!process.env.DATABASE_URL) {
+const env = getDbEnv();
+
+if (!env.DATABASE_URL) {
   throw new Error("DATABASE_URL environment variable is not set.");
 }
 
@@ -31,33 +35,26 @@ const dbLogger = new EnhancedQueryLogger({
  * 3. Default based on NODE_ENV (production = true, others = false)
  */
 function shouldUseSSL(): boolean {
-  // Check explicit DATABASE_SSL environment variable
-  const explicitSSL = process.env.DATABASE_SSL?.toLowerCase();
-  if (explicitSSL === "true" || explicitSSL === "enabled") {
-    return true;
-  }
-  if (explicitSSL === "false" || explicitSSL === "disabled") {
-    return false;
-  }
+  // 1) Explicit DATABASE_SSL
+  const explicit = env.DATABASE_SSL;
+  if (typeof explicit === "boolean") return explicit;
+  if (explicit === "true") return true;
+  if (explicit === "false") return false;
 
-  // Auto-detect from DATABASE_URL sslmode parameter
-  const databaseUrl = process.env.DATABASE_URL;
-  if (databaseUrl?.includes("sslmode=require")) {
-    return true;
-  }
-  if (databaseUrl?.includes("sslmode=disable")) {
-    return false;
-  }
+  // 2) Detect from DATABASE_URL
+  const databaseUrl = env.DATABASE_URL;
+  if (databaseUrl.includes("sslmode=require")) return true;
+  if (databaseUrl.includes("sslmode=disable")) return false;
 
-  // Default: use SSL in production, disable in development/test
-  return process.env.NODE_ENV === "production";
+  // 3) Default by NODE_ENV
+  return env.NODE_ENV === "production";
 }
 
 export const db = drizzle({
   connection: {
-    connectionString: process.env.DATABASE_URL,
+    connectionString: env.DATABASE_URL,
     ssl: shouldUseSSL(),
   },
   schema,
-  logger: process.env.NODE_ENV === "development" ? dbLogger : false,
+  logger: env.NODE_ENV === "development" ? dbLogger : false,
 });

--- a/src/infra/auth/better-auth.plugin.ts
+++ b/src/infra/auth/better-auth.plugin.ts
@@ -6,6 +6,7 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { nextCookies } from "better-auth/next-js";
 import { captcha, emailOTP, phoneNumber } from "better-auth/plugins";
 
+import { getParsedEnv } from "@/config/env";
 import { db } from "@/db";
 import { logger } from "@/infra/logging";
 
@@ -21,7 +22,7 @@ export const auth = betterAuth({
   plugins: [
     captcha({
       provider: "cloudflare-turnstile",
-      secretKey: process.env.TURNSTILE_SECRET_KEY ?? "",
+      secretKey: getParsedEnv().TURNSTILE_SECRET_KEY ?? "",
       endpoints: ["/phone-number/send-otp", "/email-otp/send-verification-otp"],
     }),
     phoneNumber({
@@ -65,8 +66,8 @@ export const auth = betterAuth({
   },
   socialProviders: {
     github: {
-      clientId: process.env.GITHUB_CLIENT_ID as string,
-      clientSecret: process.env.GITHUB_CLIENT_SECRET as string,
+      clientId: (getParsedEnv() as any).GITHUB_CLIENT_ID as string,
+      clientSecret: (getParsedEnv() as any).GITHUB_CLIENT_SECRET as string,
     },
   },
   rateLimit: {

--- a/src/infra/auth/better-auth.plugin.ts
+++ b/src/infra/auth/better-auth.plugin.ts
@@ -64,12 +64,17 @@ export const auth = betterAuth({
       return logger.info(message, ...args);
     },
   },
-  socialProviders: {
-    github: {
-      clientId: (getParsedEnv() as any).GITHUB_CLIENT_ID as string,
-      clientSecret: (getParsedEnv() as any).GITHUB_CLIENT_SECRET as string,
-    },
-  },
+  socialProviders: (() => {
+    const env = getParsedEnv();
+    return env.GITHUB_CLIENT_ID && env.GITHUB_CLIENT_SECRET
+      ? {
+          github: {
+            clientId: env.GITHUB_CLIENT_ID,
+            clientSecret: env.GITHUB_CLIENT_SECRET,
+          },
+        }
+      : {};
+  })(),
   rateLimit: {
     storage: "database",
     modelName: "rateLimit",

--- a/src/infra/auth/otp-channels.ts
+++ b/src/infra/auth/otp-channels.ts
@@ -1,35 +1,17 @@
 import "server-only";
 
-import { isProduction } from "@/config/env";
+import { getFeatureToggles, getParsedEnv } from "@/config/env";
 import { sendEmailOtp, sendSmsOtp } from "@/infra/communications";
 import { logger } from "@/infra/logging";
 
 export function shouldEnableAliyunSms(): boolean {
-  const enableSms = process.env.ENABLE_ALIYUN_SMS?.toLowerCase();
-
-  if (enableSms === "enabled" || enableSms === "true") {
-    return true;
-  }
-
-  if (enableSms === "disabled" || enableSms === "false") {
-    return false;
-  }
-
-  return isProduction();
+  const { sms } = getFeatureToggles();
+  return sms;
 }
 
 export function shouldEnableResend(): boolean {
-  const enableEmail = process.env.ENABLE_RESEND?.toLowerCase();
-
-  if (enableEmail === "enabled" || enableEmail === "true") {
-    return true;
-  }
-
-  if (enableEmail === "disabled" || enableEmail === "false") {
-    return false;
-  }
-
-  return isProduction();
+  const { email } = getFeatureToggles();
+  return email;
 }
 
 export async function sendAuthPhoneOtp(
@@ -40,15 +22,19 @@ export async function sendAuthPhoneOtp(
 
   if (!useAliyunSms) {
     logger.info(`[SMS SIMULATION] Sending OTP to ${phoneNumber}`);
+    const env = getParsedEnv();
     logger.info(
-      `[SMS SIMULATION] Environment: ${process.env.NODE_ENV}, ENABLE_ALIYUN_SMS: ${process.env.ENABLE_ALIYUN_SMS}`
+      `[SMS SIMULATION] Environment: ${env.NODE_ENV}, ENABLE_ALIYUN_SMS: ${env.ENABLE_ALIYUN_SMS as unknown as string}`
     );
     return;
   }
 
-  const success = await sendSmsOtp(phoneNumber, code);
-
-  if (!success) {
+  try {
+    const success = await sendSmsOtp(phoneNumber, code);
+    if (!success) {
+      throw new Error("Failed to send SMS");
+    }
+  } catch {
     throw new Error("Failed to send SMS");
   }
 
@@ -64,15 +50,19 @@ export async function sendAuthEmailOtp(
 
   if (!useResend) {
     logger.info(`[EMAIL SIMULATION] Sending OTP to ${email} (type: ${type})`);
+    const env = getParsedEnv();
     logger.info(
-      `[EMAIL SIMULATION] Environment: ${process.env.NODE_ENV}, ENABLE_RESEND: ${process.env.ENABLE_RESEND}`
+      `[EMAIL SIMULATION] Environment: ${env.NODE_ENV}, ENABLE_RESEND: ${env.ENABLE_RESEND as unknown as string}`
     );
     return;
   }
 
-  const success = await sendEmailOtp(email, otp);
-
-  if (!success) {
+  try {
+    const success = await sendEmailOtp(email, otp);
+    if (!success) {
+      throw new Error("Failed to send email");
+    }
+  } catch {
     throw new Error("Failed to send email");
   }
 

--- a/src/infra/auth/otp-channels.ts
+++ b/src/infra/auth/otp-channels.ts
@@ -34,7 +34,8 @@ export async function sendAuthPhoneOtp(
     if (!success) {
       throw new Error("Failed to send SMS");
     }
-  } catch {
+  } catch (error) {
+    logger.error({ err: error }, "Failed to send SMS OTP");
     throw new Error("Failed to send SMS");
   }
 
@@ -62,7 +63,8 @@ export async function sendAuthEmailOtp(
     if (!success) {
       throw new Error("Failed to send email");
     }
-  } catch {
+  } catch (error) {
+    logger.error({ err: error }, "Failed to send Email OTP");
     throw new Error("Failed to send email");
   }
 

--- a/src/infra/communications/aliyun-sms.client.ts
+++ b/src/infra/communications/aliyun-sms.client.ts
@@ -5,6 +5,7 @@ import Dypnsapi20170525, * as $Dypnsapi20170525 from "@alicloud/dypnsapi20170525
 import * as $OpenApi from "@alicloud/openapi-client";
 import * as $Util from "@alicloud/tea-util";
 
+import { getParsedEnv } from "@/config/env";
 import { createScopedLogger } from "@/infra/logging/logger";
 import { phoneNumberSchema } from "@/types/validations";
 
@@ -68,8 +69,9 @@ class AliyunSmsClient {
    */
   public async sendSms(phoneNumber: string, code: string): Promise<boolean> {
     try {
-      const signName = process.env.ALIBABA_CLOUD_SMS_SIGN_NAME;
-      const templateCode = process.env.ALIBABA_CLOUD_SMS_TEMPLATE_CODE;
+      const env = getParsedEnv();
+      const signName = (env as any).ALIBABA_CLOUD_SMS_SIGN_NAME;
+      const templateCode = (env as any).ALIBABA_CLOUD_SMS_TEMPLATE_CODE;
 
       logger.debug(
         { signName, templateCode },

--- a/src/infra/communications/aliyun-sms.client.ts
+++ b/src/infra/communications/aliyun-sms.client.ts
@@ -70,8 +70,8 @@ class AliyunSmsClient {
   public async sendSms(phoneNumber: string, code: string): Promise<boolean> {
     try {
       const env = getParsedEnv();
-      const signName = (env as any).ALIBABA_CLOUD_SMS_SIGN_NAME;
-      const templateCode = (env as any).ALIBABA_CLOUD_SMS_TEMPLATE_CODE;
+      const signName = env.ALIBABA_CLOUD_SMS_SIGN_NAME;
+      const templateCode = env.ALIBABA_CLOUD_SMS_TEMPLATE_CODE;
 
       logger.debug(
         { signName, templateCode },

--- a/src/infra/communications/resend.client.tsx
+++ b/src/infra/communications/resend.client.tsx
@@ -3,6 +3,7 @@ import "server-only";
 import { Resend } from "resend";
 
 import { OrderConfirmationEmail, OtpEmailTemplate } from "@/components/emails";
+import { getParsedEnv } from "@/config/env";
 import { createScopedLogger } from "@/infra/logging/logger";
 import type { OrderConfirmationEmailData } from "@/types/dto";
 
@@ -17,7 +18,8 @@ export class ResendEmailClient {
   private client: Resend;
 
   private constructor() {
-    const apiKey = process.env.RESEND_API_KEY;
+    const env = getParsedEnv();
+    const apiKey = env.RESEND_API_KEY;
 
     if (!apiKey) {
       logger.warn(
@@ -52,15 +54,15 @@ export class ResendEmailClient {
     code: string
   ): Promise<boolean> {
     try {
-      const fromEmail =
-        process.env.RESEND_FROM_EMAIL || "onboarding@resend.dev";
+      const env = getParsedEnv();
+      const fromEmail = (env as any).RESEND_FROM_EMAIL;
 
       logger.debug(
         { fromEmail, email: emailAddr },
         "Sending verification email"
       );
 
-      if (!process.env.RESEND_API_KEY) {
+      if (!env.RESEND_API_KEY) {
         throw new Error("Missing required email configuration: RESEND_API_KEY");
       }
 
@@ -98,8 +100,8 @@ export class ResendEmailClient {
     orderData: OrderConfirmationEmailData
   ): Promise<boolean> {
     try {
-      const fromEmail =
-        process.env.RESEND_FROM_EMAIL || "onboarding@resend.dev";
+      const env = getParsedEnv();
+      const fromEmail = (env as any).RESEND_FROM_EMAIL;
 
       logger.info(
         {
@@ -109,7 +111,7 @@ export class ResendEmailClient {
         "Sending order confirmation email"
       );
 
-      if (!process.env.RESEND_API_KEY) {
+      if (!env.RESEND_API_KEY) {
         throw new Error("Missing required email configuration: RESEND_API_KEY");
       }
 

--- a/src/infra/communications/resend.client.tsx
+++ b/src/infra/communications/resend.client.tsx
@@ -55,7 +55,7 @@ export class ResendEmailClient {
   ): Promise<boolean> {
     try {
       const env = getParsedEnv();
-      const fromEmail = (env as any).RESEND_FROM_EMAIL;
+      const fromEmail = env.RESEND_FROM_EMAIL;
 
       logger.debug(
         { fromEmail, email: emailAddr },

--- a/src/infra/http/cron-auth.ts
+++ b/src/infra/http/cron-auth.ts
@@ -52,7 +52,7 @@ export function verifyCronSecret(request: Request): boolean {
 
   // Get the expected secret from environment
   const env = getParsedEnv();
-  const expectedSecret = (env as any).CRON_SECRET;
+  const expectedSecret = env.CRON_SECRET;
 
   if (!expectedSecret) {
     logger.error(

--- a/src/infra/http/cron-auth.ts
+++ b/src/infra/http/cron-auth.ts
@@ -21,6 +21,7 @@
  */
 
 import "server-only";
+import { getParsedEnv } from "@/config/env";
 import { createScopedLogger } from "@/infra/logging/logger";
 
 const logger = createScopedLogger({ module: "cron-auth" });
@@ -50,7 +51,8 @@ export function verifyCronSecret(request: Request): boolean {
   const token = authHeader.substring(7); // Remove "Bearer " prefix
 
   // Get the expected secret from environment
-  const expectedSecret = process.env.CRON_SECRET;
+  const env = getParsedEnv();
+  const expectedSecret = (env as any).CRON_SECRET;
 
   if (!expectedSecret) {
     logger.error(

--- a/src/infra/logging/logger.ts
+++ b/src/infra/logging/logger.ts
@@ -1,13 +1,21 @@
 import pino from "pino";
 import pretty from "pino-pretty";
 
-import { isDevelopment, isTest } from "@/config/env";
+import {
+  getLogLevel as envGetLogLevel,
+  isDevelopment,
+  isTest,
+} from "@/config/env";
 
 const bootstrapLogger = pino({
   level: "warn",
   base: {
     service: "nomad",
-    environment: process.env.NODE_ENV ?? "development",
+    environment: isTest()
+      ? "test"
+      : isDevelopment()
+        ? "development"
+        : "production",
   },
   messageKey: "message",
 });
@@ -23,50 +31,30 @@ const REDACT_PATHS = [
   "verificationCode",
 ];
 
-// Environment detection flags for conditional logger configuration
-const VALID_LOG_LEVELS: pino.LevelWithSilent[] = [
-  "fatal",
-  "error",
-  "warn",
-  "info",
-  "debug",
-  "trace",
-  "silent",
-];
-
-/**
- * Determines the appropriate log level based on the current environment.
- *
- * @returns The log level to use for the pino logger
- *
- * Priority order:
- * 1. Test environment: silent (no logs during tests)
- * 2. LOG_LEVEL environment variable if set
- * 3. Development: debug level for detailed logging
- * 4. Production: info level for essential logs only
- */
-const getLogLevel = (): pino.LevelWithSilent => {
+const resolveLogLevel = (): pino.LevelWithSilent => {
   if (isTest()) return "silent";
-  if (process.env.LOG_LEVEL) {
-    const envLevel = process.env.LOG_LEVEL as pino.LevelWithSilent;
-    // Validate the environment variable
-    if (VALID_LOG_LEVELS.includes(envLevel)) {
-      return envLevel;
-    }
+  try {
+    return envGetLogLevel();
+  } catch {
+    const envLevel = process.env.LOG_LEVEL;
     bootstrapLogger.warn(
-      { envLevel: process.env.LOG_LEVEL },
+      { envLevel },
       "Invalid LOG_LEVEL provided, falling back to default"
     );
+    return isDevelopment() ? "debug" : "info";
   }
-  return isDevelopment() ? "debug" : "info";
 };
 
 // Configuration object for the pino logger with environment-specific settings
 const pinoOptions: pino.LoggerOptions = {
-  level: getLogLevel(),
+  level: resolveLogLevel(),
   base: {
     service: "nomad",
-    environment: process.env.NODE_ENV ?? "development",
+    environment: isTest()
+      ? "test"
+      : isDevelopment()
+        ? "development"
+        : "production",
   },
   messageKey: "message",
   redact: {

--- a/src/infra/notifications/auth-notification.handler.ts
+++ b/src/infra/notifications/auth-notification.handler.ts
@@ -2,11 +2,13 @@ import "server-only";
 
 import { Resend } from "resend";
 
+import { getParsedEnv } from "@/config/env";
 import { logger } from "@/infra/logging";
 import { onAuthEvent } from "@/services/auth-events";
 
-const resendApiKey = process.env.RESEND_API_KEY;
-const resendFrom = process.env.RESEND_FROM_EMAIL || "onboarding@resend.dev";
+const env = getParsedEnv();
+const resendApiKey = env.RESEND_API_KEY;
+const resendFrom = (env as any).RESEND_FROM_EMAIL || "onboarding@resend.dev";
 const resendClient = resendApiKey ? new Resend(resendApiKey) : null;
 
 async function sendSecurityNotificationEmail(

--- a/src/infra/notifications/auth-notification.handler.ts
+++ b/src/infra/notifications/auth-notification.handler.ts
@@ -8,7 +8,7 @@ import { onAuthEvent } from "@/services/auth-events";
 
 const env = getParsedEnv();
 const resendApiKey = env.RESEND_API_KEY;
-const resendFrom = (env as any).RESEND_FROM_EMAIL || "onboarding@resend.dev";
+const resendFrom = env.RESEND_FROM_EMAIL || "onboarding@resend.dev";
 const resendClient = resendApiKey ? new Resend(resendApiKey) : null;
 
 async function sendSecurityNotificationEmail(

--- a/src/infra/notifications/auth-notification.handler.ts
+++ b/src/infra/notifications/auth-notification.handler.ts
@@ -8,7 +8,7 @@ import { onAuthEvent } from "@/services/auth-events";
 
 const env = getParsedEnv();
 const resendApiKey = env.RESEND_API_KEY;
-const resendFrom = env.RESEND_FROM_EMAIL || "onboarding@resend.dev";
+const resendFrom = env.RESEND_FROM_EMAIL;
 const resendClient = resendApiKey ? new Resend(resendApiKey) : null;
 
 async function sendSecurityNotificationEmail(

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,7 @@ import { getSessionCookie } from "better-auth/cookies";
 import { isMarkdownPreferred, rewritePath } from "fumadocs-core/negotiation";
 import { NextRequest, NextResponse } from "next/server";
 
+import { isDevelopment } from "@/config/env";
 import { logger } from "@/infra/logging";
 
 const { rewrite: rewriteLLM } = rewritePath("/docs/*path", "/llms.mdx/*path");
@@ -70,7 +71,7 @@ export function middleware(request: NextRequest) {
   }
 
   // 5. Log all requests in development environment
-  if (process.env.NODE_ENV === "development") {
+  if (isDevelopment()) {
     logger.info(`[Middleware] ${request.method} ${pathname}`);
   }
 

--- a/src/services/dev-tools/dev-users.service.ts
+++ b/src/services/dev-tools/dev-users.service.ts
@@ -1,5 +1,6 @@
 import { desc, eq } from "drizzle-orm";
 
+import { isDevelopment } from "@/config/env";
 import { db } from "@/db";
 import { user, verification } from "@/db/schema";
 import { auth } from "@/infra/auth";
@@ -10,7 +11,7 @@ import type { ServiceResult } from "@/types/result";
 const logger = createScopedLogger({ module: "dev-users.service" });
 
 export async function listDevUsers(): Promise<ServiceResult<User[]>> {
-  if (process.env.NODE_ENV !== "development") {
+  if (!isDevelopment()) {
     return { success: false, error: "Not available" };
   }
 
@@ -27,7 +28,7 @@ export async function switchUser(params: {
   userId: string;
   headers: HeadersInit;
 }): Promise<ServiceResult> {
-  if (process.env.NODE_ENV !== "development") {
+  if (!isDevelopment()) {
     return { success: false, error: "Not available in production" };
   }
 


### PR DESCRIPTION
## 描述

本 PR 将环境变量访问与校验集中到 `src/config/env.ts`，通过 Zod Schema 提供类型安全与默认值处理，统一 Node/Next 运行时对环境变量的使用边界，并将日志级别、特性开关、数据库连接、Better Auth、Resend/阿里云短信等模块统一接入集中化的配置与辅助函数。

- 严格集中化与归一化：
  - Zod `envSchema` 对空字符串进行预处理，避免构建时的 “too_small” 类错误（如 `BETTER_AUTH_SECRET` 等）`src/config/env.ts:36-94`
  - 轻量特性开关读取，避免客户端/边缘场景交叉字段强校验导致的测试失败：`getFeatureToggles` `src/config/env.ts:190-204`
  - 统一日志级别解析：`getLogLevel`，非法值兜底与警告输出 `src/config/env.ts:247-262`、`src/infra/logging/logger.ts:34-46`
  - CLI/脚本 `.env` 加载器：`ensureNodeEnvLoaded`，为 Drizzle 与脚本显式加载环境 `src/config/load-env.ts:5-9`、`src/db/index.ts:14`
- 数据库配置：
  - `DATABASE_URL` 与 `DATABASE_SSL` 集中读取与推断，结合 `sslmode` 与 `NODE_ENV` 做最终决策 `src/db/index.ts:37-51`
- 运行边界策略：
  - 服务端严格解析（`getParsedEnv`），客户端/边缘使用轻量开关与兜底，避免打包阶段的空值阻塞
- OTP 管道稳定性：
  - 短信与邮箱发送模块读取轻量开关；配置缺失时模拟发送而非抛出校验错误
    - `src/infra/auth/otp-channels.ts:7-15,17-42,44-70`
    - `src/infra/communications/resend.client.tsx:20-33,52-91,99-164`
    - `src/infra/communications/aliyun-sms.client.ts:70-148`
- 日志模块整合与兜底：
  - 当 `LOG_LEVEL` 非法或解析失败时，降级为开发 `debug`/生产 `info` 并输出警告 `src/infra/logging/logger.ts:34-46`
- 框架钩子与中间件接入统一环境判断：
  - `instrumentation.ts:10-18`
  - `src/middleware.ts:73-79`

### 代码定位参考

- 日志级别解析：`src/config/env.ts:247`、`src/infra/logging/logger.ts:34`
- CLI 环境加载：`src/config/load-env.ts:5`
- Drizzle 读取环境：`src/db/index.ts:16`、`drizzle.config.ts:7-15`
- 轻量特性开关：`src/config/env.ts:190-204`
- Turnstile 配置检测：`src/config/env.ts:301-306`
- 安全通知使用集中化环境：`src/infra/notifications/auth-notification.handler.ts:9-13`

## 相关问题

关闭 # 205（如需关联 Issue，请在合并前补充编号）

## 变更类型

- [ ] Bug 修复（不会破坏现有功能的非破坏性变更）
- [ ] 新功能（添加功能的非破坏性变更）
- [ ] 破坏性变更（会导致现有功能无法正常工作的修复或功能）
- [ ] 文档更新
- [ ] 性能改进
- [x] 代码重构
- [ ] CI/CD 改进

## 测试

- 建议本地验证命令（使用 `pnpm`）：
  - `pnpm lint`（Biome 规则与边界检查）
  - `pnpm build`（验证构建通过）
  - `pnpm test:run`（运行 Vitest 全量）
  - `pnpm e2e`（Playwright E2E）
- 注意事项：
  - `.env.test` 需包含有效的 `DATABASE_URL`（含用户名与密码），否则会出现 PG SASL 密码错误
  - 在测试环境，`LOG_LEVEL` 默认解析为 `silent`，可通过显式设置覆盖

- [ ] 我已经在本地测试了这些更改
- [ ] 我已经添加了证明我的修复有效或我的功能工作的测试
- [ ] 新的和现有的单元测试在我的更改下都能通过
- [ ] 我已经检查了代码能够无错误地构建

## 截图（如果适用）

添加截图来帮助解释你的更改。

## 检查清单

- [ ] 我的代码遵循此项目的代码风格
- [ ] 我已经对自己的代码进行了自我审查
- [ ] 我已经对代码进行了注释，特别是在难以理解的地方
- [ ] 我已经对文档进行了相应的更改
- [ ] 我的更改没有产生新的警告
- [ ] 我已经添加了证明我的修复有效或我的功能工作的测试
- [ ] 新的和现有的单元测试在我的更改下都能通过

## 代码审查检查清单（供审查者使用）

- [ ] 代码可读且有良好的文档
- [ ] 更改经过了适当的测试
- [ ] 没有明显的性能问题
- [ ] 已解决安全考虑
- [ ] 破坏性变更已得到适当记录

## 附加说明

- 日志级别默认：`test=silent`、`development=debug`、`production=info`（可通过显式 `LOG_LEVEL` 覆盖）`src/config/env.ts:247-262`
- 重要环境变量的空字符串归一化为未设置（如 `BETTER_AUTH_SECRET`、`CRON_SECRET`、`GITHUB_CLIENT_ID/SECRET`），避免构建期校验错误
- `ENABLE_ALIYUN_SMS`/`ENABLE_RESEND` 支持 `enabled/disabled/true/false/""`；生产默认开启，非生产默认关闭（未显式设置时）
- 数据库 SSL 判定优先级：显式 `DATABASE_SSL` > `DATABASE_URL` 中 `sslmode` > `NODE_ENV`（生产启用）`src/db/index.ts:37-51`