### PR TITLE
fix: resolve artifacts not found issue in slidev deploy workflow

### DIFF
--- a/.github/workflows/deploy-slidev.yml
+++ b/.github/workflows/deploy-slidev.yml
@@ -45,7 +45,7 @@ jobs:
         run: pnpm add -g @slidev/cli
 
       - name: Build Slidev
-        run: slidev build content/slides/midterm-2.md --base /nomad/slides/
+        run: pnpm exec slidev build content/slides/midterm-2.md --base /nomad/slides/ --out dist
         env:
           NODE_ENV: production
 

--- a/.github/workflows/deploy-slidev.yml
+++ b/.github/workflows/deploy-slidev.yml
@@ -42,7 +42,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Slidev CLI
-        run: pnpm add -g @slidev/cli
+        run: pnpm add -g @slidev/cli@^52.8.0
 
       - name: Build Slidev
         run: pnpm exec slidev build content/slides/midterm-2.md --base /nomad/slides/ --out dist


### PR DESCRIPTION
## 描述

修复 slidev-deploy workflow 脚本中错误的构建产物输出路径导致部署失败的问题。

同时，考虑到为了避免开发者需要安装 `@slidev/cli` 依赖，我们项目没有将 `@slidev/cli` 添加到 `package.json` 文件，而是全局安装。但是存在潜在的和 `"@slidev/theme-default": "^0.25.0"` 冲突的风险，因此在 GitHub Workflow 文件中我们固定 `@slidev/cli` 版本号为 `^52.8.0`。

## 相关问题

Resolves #243 

## 变更类型

- [x] Bug 修复（不会破坏现有功能的非破坏性变更）
- [ ] 新功能（添加功能的非破坏性变更）
- [ ] 破坏性变更（会导致现有功能无法正常工作的修复或功能）
- [ ] 文档更新
- [ ] 性能改进
- [ ] 代码重构
- [x] CI/CD 改进

## 测试

- [ ] 我已经在本地测试了这些更改
- [ ] 我已经添加了证明我的修复有效或我的功能工作的测试
- [x] 新的和现有的单元测试在我的更改下都能通过
- [x] 我已经检查了代码能够无错误地构建

## 截图（如果适用）

无

## 检查清单

- [x] 我的代码遵循此项目的代码风格
- [x] 我已经对自己的代码进行了自我审查
- [x] 我已经对代码进行了注释，特别是在难以理解的地方
- [x] 我已经对文档进行了相应的更改
- [x] 我的更改没有产生新的警告
- [x] 我已经添加了证明我的修复有效或我的功能工作的测试
- [x] 新的和现有的单元测试在我的更改下都能通过

## 代码审查检查清单（供审查者使用）

- [ ] 代码可读且有良好的文档
- [ ] 更改经过了适当的测试
- [ ] 没有明显的性能问题
- [ ] 已解决安全考虑
- [ ] 破坏性变更已得到适当记录

## 附加说明

无。
